### PR TITLE
devexp: QOL improvements for devcontainer users

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres
 {
-  "name": "Node.js & MySQL",
+  "name": "InfoMedicament - Dev",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
@@ -13,8 +13,10 @@
   // This can be used to network with other containers or with the host.
   "forwardPorts": [3000, 3306, 5432],
 
-  // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "yarn install",
+  // Use non-root user 'node' inside the container
+  "remoteUser": "node",
+  "containerUser": "node",
+  "updateRemoteUserUID": true,
 
   // Configure tool-specific properties.
   "customizations" : {
@@ -23,6 +25,9 @@
     }
   },
 
-  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  // "remoteUser": "root"
+  // Stop the containers when the workspace is closed.
+  "shutdownAction": "stopCompose",
+  // Automate dependency installation
+  "postCreateCommand": "npm install",
+  "waitFor": "postCreateCommand"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    # Runs app on the same network as the mysql container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db-mysql
+    networks:
+      - dev-network
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -19,7 +19,7 @@ services:
   # We use PostgreSQL as the database for the application data.
   db-postgres:
     image: postgres:15
-    restart: unless-stopped
+    restart: on-failure
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -30,12 +30,14 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     ports:
       - "5432:5432"
+    networks:
+      - dev-network
 
 
   # This is the container for the legacy BDPM MySQL database.
   db-mysql:
     image: mysql:9
-    restart: unless-stopped
+    restart: on-failure
     volumes:
       - mysql-data:/var/lib/mysql
     environment:
@@ -46,6 +48,12 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     ports:
       - "3306:3306"
+    networks:
+      - dev-network
+
+networks:
+  dev-network:
+    driver: bridge
 
 volumes:
   mysql-data:

--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ Deux bases de données sont utilisées :
 * MySQL pour héberger une copie de la base de données publique des médicaments originale de l'ANSM.
 Ces données sont utilisés à l'identique et la base MySQL n'est pas modifiée.
 
-Pour démarrer
-facilement un environnement de développement
-avec un service MySQL et un service PostgreSQL,
-vous pouvez utiliser la configuration Dev Containers fournie.
+Pour démarrer facilement un environnement de développement avec un service MySQL et un service PostgreSQL,vous pouvez utiliser la configuration Dev Containers fournie.
 
 ## Installation
 


### PR DESCRIPTION
This commit fixes several things when using devcontainer for local development.

In devcontainer.json:
- run as non-root, node user
- rename project to something more accurate
- tell VSCode to stop the containers when it shuts down
- automatically run npm install when the container starts

In docker-compose.yml:
- use a bridge network for all services which is more standard (it's also closer to production)

Also fixes a weird multi-line sentence in the README, I don't believe there's a reason for it ?