### PR TITLE
fix: questions highlight + glossary in notice

### DIFF
--- a/src/components/glossary/WithGlossary.tsx
+++ b/src/components/glossary/WithGlossary.tsx
@@ -1,9 +1,11 @@
+"use client";
+
 import React, { Fragment } from "react";
 import WithDefinition from "@/components/glossary/WithDefinition";
 import { Definition } from "@/types/GlossaireTypes";
 import { questionKeys, questionsList } from "@/data/pages/notices_anchors";
 import QuestionKeyword from "../medicaments/QuestionKeyword";
-import { QuestionAnchors, QuestionsListFormat } from "@/types/NoticesAnchors";
+import { QuestionAnchors } from "@/types/NoticesAnchors";
 
 function escapeRegExp(text: string) {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -77,8 +79,6 @@ function WithGlossary({
   headerId?: string;
 }): React.JSX.Element {
 
-  if(!definitions) return (<>{text}</>);
-
   let elements: (React.JSX.Element | string)[] = text;
 
   if(headerId){
@@ -104,15 +104,17 @@ function WithGlossary({
       });
     });
 
-    //Find definitions
-    definitions.forEach((definition) => {
-      elements = elements
-        .map((element) => {
-          if (typeof element !== "string") return element;
-          return withDefinition(element, definition);
-        })
-        .flat();
-    });
+    if(definitions){
+      //Find definitions
+      definitions.forEach((definition) => {
+        elements = elements
+          .map((element) => {
+            if (typeof element !== "string") return element;
+            return withDefinition(element, definition);
+          })
+          .flat();
+      });
+    }
   }
 
   return (

--- a/src/components/medicaments/NoticeBlock.tsx
+++ b/src/components/medicaments/NoticeBlock.tsx
@@ -53,7 +53,7 @@ function NoticeBlock({
 
   const [definitions, setDefinitions] = useState<Definition[]>();
 
-  const loadDefinitions = useCallback(() => {
+  const loadDefinitions = useCallback(
     async () => {
       try {
         const newDefinitions = (await getGlossaryDefinitions()).filter(
@@ -63,8 +63,8 @@ function NoticeBlock({
       } catch (e) {
         Sentry.captureException(e);
       }
-    }
-  }, [setDefinitions]);
+    }, [setDefinitions]
+  );
 
   useEffect(() => {
     if(notice) {

--- a/src/types/NoticesAnchors.tsx
+++ b/src/types/NoticesAnchors.tsx
@@ -1,10 +1,5 @@
 import { JSX } from "react";
 
-type NoticesAnchorsSearchTerms = {
-  begin: string;
-  end: string;
-}
-
 export type QuestionAnchors = {
   id: string;
   highlightClass: string;

--- a/src/utils/notices/noticesUtils.tsx
+++ b/src/utils/notices/noticesUtils.tsx
@@ -107,11 +107,13 @@ function getGenericElement(content:NoticeRCPContentBlock, definitions?:Definitio
         <ul key={content.id} className={fr.cx("fr-ml-2w")} style={styles}>
           {content.content.map((li, index) => {
             const text = li.charAt(0) === '·' ? li.substring(1) : li;
-            return (
-              <li className={fr.cx("fr-text--md", "fr-mb-1w")} key={content.id+'-'+index}>
-                <WithGlossary definitions={definitions} key={content.id} text={[text]} />
-              </li>
-            )
+            if(text.trim().length > 0){
+              return (
+                <li className={fr.cx("fr-text--md", "fr-mb-1w")} key={content.id+'-'+index}>
+                  <WithGlossary definitions={definitions} key={content.id} text={[text.trim()]} />
+                </li>
+              )
+            }
           })}
         </ul>
       );


### PR DESCRIPTION
2 bugs resolution : 
- glossary links in the notices
- highlights the answers to the questions in the notices (+ navigation)