### PR TITLE
ci: more explicit config file for review apps

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,3 +1,13 @@
 {
+  "name": "infomedicament",
+  "description": "Mettre à disposition les informations et données autour du médicament aux patients et aux professionnels de santé afin de favoriser un meilleur usage des médicaments",
+  "repository": "https://github.com/betagouv/infomedicament",
+  "website": "https://infomedicament.beta.gouv.fr",
+  "env": {
+    "NEXT_PUBLIC_ENVIRONMENT": {
+      "value": "staging"
+    }
+  },
+  "copy_parent_database_urls": true,
   "addons": []
 }


### PR DESCRIPTION
This scalingo.json file is here to let Scalingo know how to deploy review apps (or one-click-deploy but we don't have that on the repo) The expected format is documented [here](https://developers.scalingo.com/scalingo-json-schema).

Nothing should change as far as review app behavior is concerned. My approach here is that explicit is better than implicit, and I also wanted to be sure that review apps were running in the staging environment.