### PR TITLE
conf(devcontainer): source .env.local for dev

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     networks:
       - dev-network
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    env_file:
+      - ../.env.local
 
   # We use PostgreSQL as the database for the application data.
   db-postgres:


### PR DESCRIPTION
This came up as I was trying to debug a build error which failed because it depended on the Grist API (which is a problem in itself).