### PR TITLE
feat: add sitemap.xml with integration test

### DIFF
--- a/src/app/sitemap.integration.test.ts
+++ b/src/app/sitemap.integration.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import sitemap from "./sitemap";
+
+vi.mock("server-only", () => ({}));
+vi.mock("server-cli-only", () => ({}));
+vi.mock("next/cache", () => ({ unstable_cache: (fn: any) => fn }));
+
+describe("sitemap (Integration)", () => {
+  it("returns a non-empty list with expected route prefixes", async () => {
+    const entries = await sitemap();
+    const urls = entries.map((e) => e.url);
+
+    expect(urls.length).toBeGreaterThan(1000);
+    expect(urls.some((u) => u.includes("/medicaments/"))).toBe(true);
+    expect(urls.some((u) => u.includes("/substances/"))).toBe(true);
+    expect(urls.some((u) => u.includes("/pathologies/"))).toBe(true);
+    expect(urls.some((u) => u.includes("/articles/"))).toBe(true);
+    expect(urls.some((u) => u.includes("/generiques/"))).toBe(true);
+    expect(urls.some((u) => u.includes("/glossaire/"))).toBe(true);
+    expect(urls.some((u) => /\/atc\/[A-Z]$/.test(u))).toBe(true);
+    expect(urls.some((u) => /\/atc\/[A-Z]\d{2}$/.test(u))).toBe(true);
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,106 @@
+import { MetadataRoute } from "next";
+import { getAllSpecialites } from "@/db/utils/specialities";
+import { getAllSubsWithSpecialites } from "@/db/utils/substances";
+import { getAllPathos } from "@/db/utils/pathologies";
+import { getAtc } from "@/db/utils/atc";
+import { getLetters } from "@/db/utils/letters";
+import { getArticles } from "@/db/utils/articles";
+import { getGlossaryLetters } from "@/db/utils/glossary";
+import { pdbmMySQL } from "@/db/pdbmMySQL";
+
+export const revalidate = 86400;
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+
+const STATIC_ROUTES = [
+  "/",
+  "/a-propos",
+  "/articles",
+  "/interactions",
+  "/mentions-legales",
+  "/politique-de-confidentialite",
+  "/rechercher",
+  "/statistiques",
+];
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [
+    specialites,
+    substances,
+    pathos,
+    atcData,
+    articles,
+    glossaryLetters,
+    medLetters,
+    subsLetters,
+    pathoLetters,
+    genLetters,
+    genericGroups,
+  ] = await Promise.all([
+    getAllSpecialites(),
+    getAllSubsWithSpecialites(),
+    getAllPathos(),
+    getAtc(),
+    getArticles(),
+    getGlossaryLetters(),
+    getLetters("specialites"),
+    getLetters("substances"),
+    getLetters("pathos"),
+    getLetters("generiques"),
+    pdbmMySQL.selectFrom("GroupeGene").select("SpecId").distinct().execute(),
+  ]);
+
+  const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.map((path) => ({
+    url: `${BASE_URL}${path}`,
+  }));
+
+  const medicamentEntries: MetadataRoute.Sitemap = specialites.map((s) => ({
+    url: `${BASE_URL}/medicaments/${s.SpecId.trim()}`,
+  }));
+
+  const articleEntries: MetadataRoute.Sitemap = articles.map((a) => ({
+    url: `${BASE_URL}/articles/${a.slug}`,
+  }));
+
+  const substanceEntries: MetadataRoute.Sitemap = substances.map((s) => ({
+    url: `${BASE_URL}/substances/${s.NomId.trim()}`,
+  }));
+
+  const pathoEntries: MetadataRoute.Sitemap = pathos.map((p) => ({
+    url: `${BASE_URL}/pathologies/${p.codePatho.trim()}`,
+  }));
+
+  const atcEntries: MetadataRoute.Sitemap = [
+    ...atcData.map((a) => ({ url: `${BASE_URL}/atc/${a.code}` })),
+    ...atcData.flatMap((a) =>
+      a.children.map((c) => ({ url: `${BASE_URL}/atc/${c.code}` }))
+    ),
+  ];
+
+  const genericEntries: MetadataRoute.Sitemap = genericGroups.map((g) => ({
+    url: `${BASE_URL}/generiques/${g.SpecId.trim()}`,
+  }));
+
+  const glossaireEntries: MetadataRoute.Sitemap = glossaryLetters.map((l) => ({
+    url: `${BASE_URL}/glossaire/${l}`,
+  }));
+
+  const alphaListEntries: MetadataRoute.Sitemap = [
+    ...medLetters.map((l) => ({ url: `${BASE_URL}/alpha_lists/medicaments/${l}` })),
+    ...subsLetters.map((l) => ({ url: `${BASE_URL}/alpha_lists/substances/${l}` })),
+    ...pathoLetters.map((l) => ({ url: `${BASE_URL}/alpha_lists/pathologies/${l}` })),
+    ...genLetters.map((l) => ({ url: `${BASE_URL}/alpha_lists/generiques/${l}` })),
+  ];
+
+  return [
+    ...staticEntries,
+    ...medicamentEntries,
+    ...articleEntries,
+    ...substanceEntries,
+    ...pathoEntries,
+    ...atcEntries,
+    ...genericEntries,
+    ...glossaireEntries,
+    ...alphaListEntries,
+  ];
+}


### PR DESCRIPTION
Covers all route types: static pages, medicaments, substances, pathologies, ATC codes, generics, articles, glossaire, and alphabetical lists.
Revalidates every 24h. Integration test guards against silent breakage from route renames or empty DB queries.

I set "NEXT_PUBLIC_URL" on scalingo already. For review apps, the URLs in the sitemap will be "wrong" (it will be the staging URL instead)