### PR TITLE
fix(proxy): raise rate limit to 1000 req/min in staging

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isRateLimited } from "@/utils/rate-limit";
 
-// Rate limit: 200 requests per minute per IP
-const RATE_LIMIT = 200; // TODO: we shouldn't need such a high limit
+// Rate limit: 200 req/min in production, 1000 in staging (review apps run a single container
+// so the per-container limit is not multiplied across the fleet like in production)
+const RATE_LIMIT = process.env.NEXT_PUBLIC_ENVIRONMENT === "staging" ? 1000 : 200;
 const RATE_WINDOW_MS = 60_000;
 
 export function proxy(req: NextRequest) {


### PR DESCRIPTION
Quick fix for the "Too many requests" errors we see on review apps

The real fix is #233 though.