### PR TITLE
feat(build): use generateStaticParams to SSG alpha_lists and glossaire

### DIFF
--- a/src/app/(container)/alpha_lists/generiques/[letter]/page.tsx
+++ b/src/app/(container)/alpha_lists/generiques/[letter]/page.tsx
@@ -8,6 +8,11 @@ import { DataTypeEnum } from "@/types/DataTypes";
 
 export const dynamic = "error";
 export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const letters = await getLetters("generiques");
+  return letters.map((letter) => ({ letter }));
+}
 const PAGE_LABEL: string = "Liste des groupes génériques";
 
 export default async function Page(props: {

--- a/src/app/(container)/alpha_lists/indications/[letter]/page.tsx
+++ b/src/app/(container)/alpha_lists/indications/[letter]/page.tsx
@@ -8,6 +8,11 @@ import { DataTypeEnum } from "@/types/DataTypes";
 
 export const dynamic = "error";
 export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const letters = await getLetters("indications");
+  return letters.map((letter) => ({ letter }));
+}
 const PAGE_LABEL: string = "Liste des indications";
 
 export default async function Page(props: {

--- a/src/app/(container)/alpha_lists/medicaments/[letter]/page.tsx
+++ b/src/app/(container)/alpha_lists/medicaments/[letter]/page.tsx
@@ -9,6 +9,11 @@ import { DataTypeEnum } from "@/types/DataTypes";
 
 export const dynamic = "error";
 export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const letters = await getLetters("specialites");
+  return letters.map((letter) => ({ letter }));
+}
 const PAGE_LABEL: string = "Liste des médicaments";
 
 export default async function Page(props: {

--- a/src/app/(container)/alpha_lists/substances/[letter]/page.tsx
+++ b/src/app/(container)/alpha_lists/substances/[letter]/page.tsx
@@ -8,6 +8,11 @@ import { DataTypeEnum } from "@/types/DataTypes";
 
 export const dynamic = "error";
 export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const letters = await getLetters("substances");
+  return letters.map((letter) => ({ letter }));
+}
 const PAGE_LABEL: string = "Liste des substances";
 
 export default async function Page(props: {

--- a/src/app/(container)/glossaire/[letter]/page.tsx
+++ b/src/app/(container)/glossaire/[letter]/page.tsx
@@ -9,6 +9,11 @@ import RatingToaster from "@/components/rating/RatingToaster";
 
 export const dynamic = "error";
 export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const letters = await getGlossaryLetters();
+  return letters.map((letter) => ({ letter }));
+}
 const PAGE_LABEL: string = "Glossaire";
 
 export default async function Page(props: {


### PR DESCRIPTION
This is a quick win. All those pages are now pre-rendered as static HTML.

Originally from #237 