### PR TITLE
feat: warmup top 500 meds

### DIFF
--- a/src/app/(container)/medicaments/[CIS]/page.tsx
+++ b/src/app/(container)/medicaments/[CIS]/page.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { notFound } from "next/navigation";
 import { Metadata, ResolvingMetadata } from "next";
 import { fr } from "@codegouvfr/react-dsfr";
@@ -29,6 +31,22 @@ import { SpecComposant, SubstanceNom } from "@/db/pdbmMySQL/types";
 
 export const dynamic = "error";
 export const dynamicParams = true;
+export const revalidate = 86400; // 24h ISR: refresh top-500 between deploys
+
+// Prerender the top ~500 medicaments at build time so they are served as static
+// HTML before the first request. Other CIS are still rendered on-demand
+// (dynamicParams = true). The list is curated in scripts/seed_cis_codes.txt.
+export async function generateStaticParams() {
+  const file = readFileSync(
+    join(process.cwd(), "scripts/seed_cis_codes.txt"),
+    "utf8",
+  );
+  return file
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((CIS) => ({ CIS }));
+}
 
 async function fetchMedicamentData(
   CIS: string,

--- a/src/app/(container)/medicaments/[CIS]/page.tsx
+++ b/src/app/(container)/medicaments/[CIS]/page.tsx
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { notFound } from "next/navigation";
 import { Metadata, ResolvingMetadata } from "next";
 import { fr } from "@codegouvfr/react-dsfr";
@@ -10,6 +8,7 @@ import {
 import Breadcrumb from "@codegouvfr/react-dsfr/Breadcrumb";
 import { getAtc1, getAtc2 } from "@/db/utils/atc";
 import { getSpecialite } from "@/db/utils";
+import { getWarmupCISCodes } from "@/db/utils/warmup";
 import { pdbmMySQL } from "@/db/pdbmMySQL";
 import ContentContainer from "@/components/generic/ContentContainer";
 import RatingToaster from "@/components/rating/RatingToaster";
@@ -35,17 +34,10 @@ export const revalidate = 86400; // 24h ISR: refresh top-500 between deploys
 
 // Prerender the top ~500 medicaments at build time so they are served as static
 // HTML before the first request. Other CIS are still rendered on-demand
-// (dynamicParams = true). The list is curated in scripts/seed_cis_codes.txt.
+// (dynamicParams = true). Returns [] on unseeded DBs (e.g. review-app builds).
 export async function generateStaticParams() {
-  const file = readFileSync(
-    join(process.cwd(), "scripts/seed_cis_codes.txt"),
-    "utf8",
-  );
-  return file
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((CIS) => ({ CIS }));
+  const cisCodes = await getWarmupCISCodes();
+  return cisCodes.map((CIS) => ({ CIS }));
 }
 
 async function fetchMedicamentData(

--- a/src/db/utils/warmup.ts
+++ b/src/db/utils/warmup.ts
@@ -1,0 +1,40 @@
+import "server-cli-only";
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import db from "@/db";
+
+/**
+ * CIS codes of the top ~500 medicaments to prerender at build time (warmup).
+ * Curated list maintained in scripts/seed_cis_codes.txt.
+ */
+function readSeedCISCodes(): string[] {
+  const file = readFileSync(
+    join(process.cwd(), "scripts/seed_cis_codes.txt"),
+    "utf8",
+  );
+  return file
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Returns the CIS codes to statically prerender for the warmup, or an empty
+ * array when the Postgres DB has no data yet.
+ *
+ * Review apps build *before* their Postgres is seeded from staging, so the DB
+ * is empty at build time. Prerendering the medicament pages then would bake
+ * empty/fallback HTML (or break the build). We therefore only warm up when
+ * `resume_medicaments` is non-empty (i.e. on populated staging/prod builds).
+ */
+export async function getWarmupCISCodes(): Promise<string[]> {
+  const row = await db
+    .selectFrom("resume_medicaments")
+    .select(({ fn }) => fn.countAll<number>().as("count"))
+    .executeTakeFirst();
+
+  if (!row || Number(row.count) === 0) return [];
+
+  return readSeedCISCodes();
+}


### PR DESCRIPTION
Static pre-rendering for the top 500-ish CIS codes contained in `/scripts/seed_cis_codes.txt`

Does not run on review apps.

local / production / staging build times should see a small increase.

Another approach I explored was to curl pages after a first deploy but this was simply not practical and would probably doesn't work in a multi-workers environment anyways.
