### PR TITLE
feat(search): rank and autocomplete at the spécialité level

### DIFF
--- a/src/components/AutocompleteSearch.test.tsx
+++ b/src/components/AutocompleteSearch.test.tsx
@@ -16,6 +16,8 @@ vi.mock("@/services/tracking", () => ({
 const mockSearchResults = [
   {
     groupName: "DOLIPRANE",
+    specName: "DOLIPRANE 1000 mg",
+    specId: "61234567",
     composants: "paracetamol",
     specialites: [],
     indicationsIds: [],
@@ -23,6 +25,7 @@ const mockSearchResults = [
     subsIds: [],
     matchReasons: [],
     shortSpecialites: [],
+    score: 5,
   },
 ];
 
@@ -112,5 +115,33 @@ describe("AutocompleteSearchInput", () => {
     expect(screen.getByRole("listbox")).toBeDefined();
     fireEvent.keyDown(input, { key: "Escape" });
     expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("should navigate to the medicament page when selecting a spécialité", () => {
+    renderAutocomplete();
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "doli" } });
+
+    const option = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent === "Doliprane 1000 mg")!;
+    fireEvent.mouseDown(option);
+
+    expect(mockPush).toHaveBeenCalledWith("/medicaments/61234567");
+  });
+
+  it("should navigate to the medicament page for a spécialité even when onSearch is provided", () => {
+    const onSearch = vi.fn();
+    renderAutocomplete(onSearch);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "doli" } });
+
+    const option = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent === "Doliprane 1000 mg")!;
+    fireEvent.mouseDown(option);
+
+    expect(mockPush).toHaveBeenCalledWith("/medicaments/61234567");
+    expect(onSearch).not.toHaveBeenCalled();
   });
 });

--- a/src/components/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch.tsx
@@ -10,6 +10,13 @@ import { useRouter } from "next/navigation";
 import { trackSearchEvent } from "@/services/tracking";
 import { SearchResultItem } from "@/types/SearchTypes";
 
+type AutocompleteOption = {
+  label: string;
+  type: "group" | "specialite";
+  specId?: string;
+  score: number;
+};
+
 type SearchInputProps = {
   name: string;
   initialValue?: string;
@@ -49,21 +56,54 @@ export function AutocompleteSearchInput({
     },
   ) as { data: SearchResultItem[] };
 
-  const options = searchResults
-    ? searchResults.map((result) => formatSpecName(result.groupName))
-      .filter(Boolean)
-      .filter((v,i,a) => a.indexOf(v)==i) //unique
-    : [];
+  // Build a mixed list: each spécialité (→ medicament page) plus its generic group
+  // (→ full search page). The group entry is kept so users can still browse all variants.
+  const options: AutocompleteOption[] = (() => {
+    if (!searchResults) return [];
+    const specOptions: AutocompleteOption[] = [];
+    const groupScores = new Map<string, number>();
+    for (const result of searchResults) {
+      if (result.specName && result.specId) {
+        specOptions.push({
+          label: formatSpecName(result.specName),
+          type: "specialite",
+          specId: result.specId,
+          score: result.score,
+        });
+      }
+      if (result.groupName) {
+        const groupLabel = formatSpecName(result.groupName);
+        groupScores.set(groupLabel, Math.max(groupScores.get(groupLabel) ?? 0, result.score));
+      }
+    }
+    const groupOptions: AutocompleteOption[] = [...groupScores.entries()].map(
+      ([label, score]) => ({ label, type: "group", score }),
+    );
+    return [...groupOptions, ...specOptions]
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        // on a tie, surface the group entry above its variants
+        if (a.type !== b.type) return a.type === "group" ? -1 : 1;
+        return a.label.localeCompare(b.label, "fr");
+      })
+      .filter((opt, i, arr) => arr.findIndex((o) => o.type === opt.type && o.label === opt.label) === i)
+      .slice(0, 10);
+  })();
 
-  function selectOption(value: string) {
-    setInputValue(value);
+  function selectOption(option: AutocompleteOption) {
+    setInputValue(option.label);
     setIsOpen(false);
     setActiveIndex(-1);
+    if (option.type === "specialite") {
+      trackSearchEvent(option.label);
+      router.push(`/medicaments/${option.specId}`);
+      return;
+    }
     if (onSearch) {
-      onSearch(value);
+      onSearch(option.label);
     } else {
-      trackSearchEvent(value);
-      router.push(`/rechercher?s=${value}`);
+      trackSearchEvent(option.label);
+      router.push(`/rechercher?s=${option.label}`);
     }
   }
 
@@ -140,7 +180,7 @@ export function AutocompleteSearchInput({
         >
           {options.map((option, index) => (
             <li
-              key={`${option}-${index}`}
+              key={`${option.type}-${option.label}-${index}`}
               id={`${id}-option-${index}`}
               role="option"
               aria-selected={index === activeIndex}
@@ -158,7 +198,7 @@ export function AutocompleteSearchInput({
                   : undefined,
               }}
             >
-              {option}
+              {option.label}
             </li>
           ))}
         </ul>

--- a/src/db/migrations/20260615000000_search_index_spec_id.ts
+++ b/src/db/migrations/20260615000000_search_index_spec_id.ts
@@ -1,0 +1,17 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Add spec_id so name tokens can be attributed to a specific spécialité.
+  // Nullable: substance/atc/indication tokens are group-level and leave it NULL.
+  await db.schema
+    .alterTable("search_index")
+    .addColumn("spec_id", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("search_index")
+    .dropColumn("spec_id")
+    .execute();
+}

--- a/src/db/seeds/1725439927263_searchIndex.ts
+++ b/src/db/seeds/1725439927263_searchIndex.ts
@@ -86,6 +86,7 @@ export async function seed(db: Kysely<any>): Promise<void> {
       groupName: string,
       token: string,
       matchLabel: string,
+      specId: string | null,
     ) {
       await trx
         .insertInto("search_index")
@@ -94,6 +95,7 @@ export async function seed(db: Kysely<any>): Promise<void> {
           match_type: matchType,
           group_name: groupName,
           match_label: matchLabel,
+          spec_id: specId,
         }))
         .execute();
       totalRows++;
@@ -108,10 +110,10 @@ export async function seed(db: Kysely<any>): Promise<void> {
         const ciscode = spec[0]; // SpecId
         const specName = spec[1]; // SpecDenom01
         if (specName) {
-          await addIndex("name", gn, specName, specName);
+          await addIndex("name", gn, specName, specName, ciscode);
         }
         if (ciscode) {
-          await addIndex("name", gn, ciscode, ciscode);
+          await addIndex("name", gn, ciscode, ciscode, ciscode);
         }
       }
 
@@ -120,7 +122,7 @@ export async function seed(db: Kysely<any>): Promise<void> {
       for (const subsId of subsIds) {
         const nomLib = substanceMap.get(subsId.trim());
         if (nomLib) {
-          await addIndex("substance", gn, nomLib, nomLib);
+          await addIndex("substance", gn, nomLib, nomLib, null);
         }
       }
 
@@ -129,7 +131,7 @@ export async function seed(db: Kysely<any>): Promise<void> {
       for (const code of indicationsIds) {
         const nomIndication = indicationsMap.get(code);
         if (nomIndication) {
-          await addIndex("indication", gn, nomIndication, nomIndication);
+          await addIndex("indication", gn, nomIndication, nomIndication, null);
         }
       }
 
@@ -144,12 +146,12 @@ export async function seed(db: Kysely<any>): Promise<void> {
         }
         for (const prefix of prefixes) {
           // Index the ATC code itself (e.g., "N05BA01") so professionals can search by code
-          await addIndex("atc", gn, prefix, prefix);
+          await addIndex("atc", gn, prefix, prefix, null);
           // Index ATC labels for this code
           const labels = atcLabelMap.get(prefix);
           if (labels) {
             for (const label of labels) {
-              await addIndex("atc", gn, label, label);
+              await addIndex("atc", gn, label, label, null);
             }
           }
         }

--- a/src/db/types.d.ts
+++ b/src/db/types.d.ts
@@ -49,6 +49,7 @@ interface SearchIndexTable {
   match_type: "name" | "substance" | "atc" | "indication";
   group_name: string;
   match_label: string;
+  spec_id?: string | null;
 }
 
 interface LeafletImagesTable {

--- a/src/db/utils/search.test.ts
+++ b/src/db/utils/search.test.ts
@@ -197,3 +197,32 @@ describe("computeSortScore", () => {
     expect(high).toBeGreaterThan(low);
   });
 });
+
+describe("Search Engine (per-spécialité ranking)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(formatSpecialitesResume).mockImplementation((spec) =>
+      spec.map((g: any) => ({ ...g, indicationsDetails: [] })),
+    );
+    vi.mocked(getResumeSpecsATCLabels).mockImplementation(async (spec) => spec);
+  });
+
+  it("ranks the variant whose name best matches the query above its siblings", async () => {
+    // Name tokens of two variants in the same group, attributed to their spec_id
+    mockExecute.mockResolvedValueOnce([
+      { match_type: "name", group_name: "DOLIPRANE", match_label: "DOLIPRANE 1000 mg", token: "doliprane 1000 mg", spec_id: "CIS1000", sml: 0.95 },
+      { match_type: "name", group_name: "DOLIPRANE", match_label: "DOLIPRANE 500 mg", token: "doliprane 500 mg", spec_id: "CIS500", sml: 0.6 },
+    ]);
+    // resume_specialites returns one row per spécialité
+    mockExecute.mockResolvedValueOnce([
+      { ...makeGroup("DOLIPRANE"), specId: "CIS1000", specName: "DOLIPRANE 1000 mg" },
+      { ...makeGroup("DOLIPRANE"), specId: "CIS500", specName: "DOLIPRANE 500 mg" },
+    ]);
+
+    const results = await getSearchResults("doliprane 1000");
+
+    expect(results).toHaveLength(2);
+    expect(results[0].specId).toBe("CIS1000");
+    expect(results[1].specId).toBe("CIS500");
+  });
+});

--- a/src/db/utils/search.ts
+++ b/src/db/utils/search.ts
@@ -55,6 +55,9 @@ export const getSearchResults = unstable_cache(async function (
 
   // Group by group_name to deduplicate, collect best score + match reasons
   const groupMap = new Map<string, { score: number; reasons: MatchReason[] }>();
+  // Per-spécialité name similarity: best sml of a "name" token attributed to a specId.
+  // Lets us rank variants within a group (e.g. "Doliprane 1000" above "Doliprane 500").
+  const specNameSml = new Map<string, number>();
   for (const match of matches) {
     const matchGroup = groupMap.get(match.group_name);
     const reason: MatchReason = { type: match.match_type, label: match.match_label };
@@ -67,6 +70,9 @@ export const getSearchResults = unstable_cache(async function (
       }
     } else {
       groupMap.set(match.group_name, { score: match.sml, reasons: [reason] });
+    }
+    if (match.match_type === "name" && match.spec_id) {
+      specNameSml.set(match.spec_id, Math.max(specNameSml.get(match.spec_id) ?? 0, match.sml));
     }
   }
 
@@ -88,21 +94,22 @@ export const getSearchResults = unstable_cache(async function (
   const formatted = formatSpecialitesResume(rawGroups);
   const withATC = await getResumeSpecsATCLabels(formatted);
 
-  // Attach match reasons, sort by score, cap output at 200 to keep cache entries bounded
+  // Attach match reasons, score per spécialité, sort, cap output at 200 to keep cache entries bounded
   return withATC
-    .map((group) => {
-      const matchReasons = groupMap.get(group.groupName)?.reasons ?? [];
+    .map((spec) => {
+      const matchReasons = groupMap.get(spec.groupName)?.reasons ?? [];
+      // Prefer this spécialité's own name similarity so variants rank against the query
+      // individually; fall back to the group's best score for substance/atc/indication matches.
+      const baseSml = specNameSml.get(spec.specId) ?? groupMap.get(spec.groupName)?.score ?? 0;
       return {
-        ...group,
+        ...spec,
         matchReasons,
-        score: computeSortScore(query, group.groupName, group.composants, matchReasons, groupMap.get(group.groupName)?.score ?? 0),
+        score: computeSortScore(query, spec.specName, spec.composants, matchReasons, baseSml),
       };
     })
     .sort((a, b) => {
-      const scoreA = computeSortScore(query, a.groupName, a.composants, a.matchReasons, groupMap.get(a.groupName)?.score ?? 0);
-      const scoreB = computeSortScore(query, b.groupName, b.composants, b.matchReasons, groupMap.get(b.groupName)?.score ?? 0);
-      if (scoreB !== scoreA) return scoreB - scoreA;
-      return a.groupName.localeCompare(b.groupName, "fr"); // alphabetical tiebreaker
+      if (b.score !== a.score) return b.score - a.score;
+      return a.specName.localeCompare(b.specName, "fr"); // alphabetical tiebreaker
     })
     .slice(0, 200);
 },

--- a/src/db/utils/searchScoring.ts
+++ b/src/db/utils/searchScoring.ts
@@ -2,7 +2,7 @@ import { MatchReason } from "@/types/SearchTypes";
 
 export function computeSortScore(
     query: string,
-    groupName: string,
+    specName: string,
     composants: string,
     matchReasons: MatchReason[],
     baseSmlScore: number,
@@ -11,8 +11,8 @@ export function computeSortScore(
     const hasSubstance = matchReasons.some((r) => r.type === "substance");
     const substanceLabel = matchReasons.find((r) => r.type === "substance")?.label ?? "";
 
-    if (hasName && groupName.toLowerCase().startsWith(query.toLowerCase()))
-        return 6 + baseSmlScore; // name starts with query
+    if (hasName && specName.toLowerCase().startsWith(query.toLowerCase()))
+        return 6 + baseSmlScore; // spécialité name starts with query
     if (hasName) return 4 + baseSmlScore; // name contains query
     if (hasSubstance && !composants.includes(",")) return 3 + baseSmlScore; // single substance
     // Check if matched substance is the first in the composants list (both from DB, same encoding)


### PR DESCRIPTION
  Search previously discovered and scored results only at the generic-group
  level, so every spécialité in a group shared one score and the autocomplete
  collapsed everything to the group name and routed to the search page.

  - search_index: add nullable spec_id column (migration); name tokens (spec name + CIS) are now attributed to their spécialité, group-level tokens (substance/atc/indication) stay NULL
  - seed: populate spec_id on name rows
  - search.ts: build a per-spécialité name-similarity map and score each spécialité on its own name match (falling back to the group score for substance/atc/indication matches), so e.g. "Doliprane 1000" outranks "Doliprane 500"
  - searchScoring: name-start tier now tests the spécialité name
  - autocomplete: list individual spécialités (/medicaments/{specId}) alongside the group entry (/rechercher); group still surfaces on score ties
  - tests for per-spécialité ranking and spécialité → medicament navigation

  Requires running migrate:latest + seed-search-index. Nullable spec_id keeps
  search working (group-level fallback) before the reseed.