### PR TITLE
feat(search): expand queries with curated lay-term synonyms

### DIFF
--- a/scripts/syncWithGrist.ts
+++ b/scripts/syncWithGrist.ts
@@ -7,11 +7,16 @@ import { type Insertable } from "kysely";
 // We're converting some values that are numeric in Grist to strings in our DB
 const safeString = (val: any) => (val === null || val === undefined) ? null : String(val).trim();
 
+// Normalize lay-term aliases the same way search queries are normalized (lowercase, unaccented),
+// so stored aliases line up with the normalized query at search time.
+const normalizeAlias = (val: any) =>
+  String(val ?? "").toLowerCase().normalize("NFD").replace(/\p{Mn}/gu, "").trim();
+
 async function syncTable<TN extends keyof Database>(
     tableName: TN,
     gristTableId: string,
     gristColumns: string[],
-    mapper: (record: any) => Insertable<Database[TN]>
+    mapper: (record: any) => Insertable<Database[TN]> | Insertable<Database[TN]>[]
 ) {
     console.log(`Fetching ${gristTableId} from Grist document ${process.env.GRIST_DOC_ID}...`);
     const gristData = await getGristTableData(gristTableId, gristColumns);
@@ -21,10 +26,11 @@ async function syncTable<TN extends keyof Database>(
         return;
     }
 
-    // Mapping Grist records to our DB schema
-    const rows = gristData.map((r, index) => {
+    // Mapping Grist records to our DB schema (a record may map to several rows)
+    const rows = gristData.flatMap((r, index) => {
         try {
-            return mapper(r);
+            const mapped = mapper(r);
+            return Array.isArray(mapped) ? mapped : [mapped];
         } catch (e) {
             console.error(`❌ Error mapping line ${index} of table ${gristTableId}`, r);
             throw e;
@@ -38,7 +44,9 @@ async function syncTable<TN extends keyof Database>(
         await trx.deleteFrom(tableName).execute();
 
         // Insert new data
-        await trx.insertInto(tableName).values(rows).execute();
+        if (rows.length) {
+            await trx.insertInto(tableName).values(rows).execute();
+        }
     });
 }
 
@@ -150,6 +158,19 @@ async function main() {
                 definition_sous_classe: r.fields.Libelles_niveau_2_Definition_sous_classe,
             })
         );
+
+        // 9. SEARCH SYNONYMS (lay term → medical term)
+        // One Grist row per canonical; the Alias cell may list several lay terms,
+        // comma-separated. Each alias becomes its own row in search_synonyms.
+        await syncTable('search_synonyms', 'SearchSynonyms', ['Alias', 'Canonical'], (r) => {
+            const canonical = safeString(r.fields.Canonical); // accented form, normalized at query time
+            if (!canonical) return [];
+            const aliases = String(r.fields.Alias ?? "")
+                .split(",")
+                .map(normalizeAlias)
+                .filter(Boolean);
+            return aliases.map((alias) => ({ alias, canonical }));
+        });
 
         console.log("✅ Synchronization complete!");
         process.exit(0);

--- a/src/app/(container)/rechercher/page.tsx
+++ b/src/app/(container)/rechercher/page.tsx
@@ -1,4 +1,4 @@
-import { getSearchResults } from "@/db/utils";
+import { getSearchResults, getSynonymSuggestion } from "@/db/utils";
 import { getArticlesFromSearchResults } from "@/db/utils/articles";
 import SearchPage from "@/components/search/SearchPage";
 import RatingToaster from "@/components/rating/RatingToaster";
@@ -9,7 +9,12 @@ export default async function Page(props: {
 }) {
   const searchParams = await props.searchParams;
   const search = searchParams && "s" in searchParams && searchParams["s"];
-  const results = search ? await getSearchResults(searchParams["s"]) : [];
+  const [results, synonymTerms] = search
+    ? await Promise.all([
+        getSearchResults(searchParams["s"]),
+        getSynonymSuggestion(searchParams["s"]),
+      ])
+    : [[], []];
   // const articlesList = results.length > 0
   //   ? await getArticlesFromSearchResults(results)
   //   : [];
@@ -20,6 +25,7 @@ export default async function Page(props: {
       <SearchPage
         search={search ? search : undefined}
         searchResults={results}
+        synonymTerms={synonymTerms}
         articlesList={articlesList}
       />
       <RatingToaster

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { fr } from "@codegouvfr/react-dsfr";
+import styled from "styled-components";
 import AutocompleteSearch from "@/components/AutocompleteSearch";
 import ContentContainer from "@/components/generic/ContentContainer";
 import SearchResultsList from "@/components/search/SearchResultsList";
@@ -8,9 +9,14 @@ import { HTMLAttributes } from "react";
 import { ArticleCardResume } from "@/types/ArticlesTypes";
 import { SearchResultItem } from "@/types/SearchTypes";
 
+const SynonymSuggestion = styled.p`
+  color: var(--text-mention-grey);
+`;
+
 interface SearchPageProps extends HTMLAttributes<HTMLDivElement> {
   search?: string;
   searchResults?: SearchResultItem[];
+  synonymTerms?: string[];
   articlesList?: ArticleCardResume[];
   //For now we are not displaying articles but we keep it in the process
 }
@@ -18,6 +24,7 @@ interface SearchPageProps extends HTMLAttributes<HTMLDivElement> {
 function SearchPage({
   search,
   searchResults,
+  synonymTerms,
   articlesList
 }: SearchPageProps) {
 
@@ -31,6 +38,13 @@ function SearchPage({
           />
         </div>
       </div>
+      {synonymTerms && synonymTerms.length > 0 && (
+        <div className={fr.cx("fr-grid-row")}>
+          <SynonymSuggestion className={fr.cx("fr-col-12", "fr-col-lg-9", "fr-col-md-10", "fr-text--sm", "fr-mb-2w")}>
+            Vouliez-vous dire : <strong>{synonymTerms.join(", ")}</strong> ?
+          </SynonymSuggestion>
+        </div>
+      )}
       {searchResults && searchResults.length > 0 ? (
         <SearchResultsList
           resultsList={searchResults}

--- a/src/db/migrations/20260616000000_search_synonyms.ts
+++ b/src/db/migrations/20260616000000_search_synonyms.ts
@@ -1,0 +1,26 @@
+import { type Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Hand-curated lay-term → medical-term mappings (e.g. "mal de tête" → "céphalées").
+  // Loaded at query time to expand searches against the existing trigram search_index.
+  // `alias` is stored normalized (lowercase, unaccented); `canonical` keeps its accented
+  // form for display and is normalized at query time when used as a search term.
+  await db.schema
+    .createTable("search_synonyms")
+    .ifNotExists()
+    .addColumn("id", "serial", (col) => col.primaryKey())
+    .addColumn("alias", "text", (col) => col.notNull())
+    .addColumn("canonical", "text", (col) => col.notNull())
+    .execute();
+
+  await db.schema
+    .createIndex("search_synonyms_alias_idx")
+    .ifNotExists()
+    .on("search_synonyms")
+    .column("alias")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable("search_synonyms").ifExists().execute();
+}

--- a/src/db/types.d.ts
+++ b/src/db/types.d.ts
@@ -3,6 +3,7 @@ import { Selectable } from "kysely";
 
 export interface Database {
   search_index: SearchIndexTable;
+  search_synonyms: SearchSynonymsTable;
   leaflet_images: LeafletImagesTable;
   presentations: PresentationTable;
   rcp: RcpTable;
@@ -50,6 +51,12 @@ interface SearchIndexTable {
   group_name: string;
   match_label: string;
   spec_id?: string | null;
+}
+
+interface SearchSynonymsTable {
+  id: Generated<number>;
+  alias: string; // lay term, stored normalized (lowercase, unaccented)
+  canonical: string; // medical term, accented form; normalized at query time
 }
 
 interface LeafletImagesTable {
@@ -421,6 +428,7 @@ interface IndicationsTable {
 
 export type LeafletImage = Selectable<LeafletImagesTable>;
 export type SearchResult = Selectable<SearchIndexTable>;
+export type SearchSynonym = Selectable<SearchSynonymsTable>;
 export type PresentationDetail = Selectable<PresentationTable>;
 export type RCPContent = Selectable<RcpContentTable>;
 export type Rating = Selectable<RatingTable>;

--- a/src/db/utils/index.ts
+++ b/src/db/utils/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./specialities";
 export { getPresentations, presentationIsComm } from "./presentation";
 export { getSearchResults } from "./search";
+export { getSynonymSuggestion } from "./searchSynonyms";
 export { groupGeneNameToDCI } from "@/displayUtils";
 
 export const getLeafletImage = async ({ src }: { src: string }) => {

--- a/src/db/utils/search.test.ts
+++ b/src/db/utils/search.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { getSearchResults } from "./search";
 import { computeSortScore } from "./searchScoring";
+import { getSynonymMap } from "./searchSynonyms";
 import { getResumeSpecsATCLabels } from "./atc";
 import { formatSpecialitesResume } from "@/utils/specialites";
 import { MatchReason } from "@/types/SearchTypes";
@@ -40,6 +41,13 @@ vi.mock("@/db/pdbmMySQL", () => ({ pdbmMySQL: {} }));
 vi.mock("@/data/grist/specialites");
 vi.mock("@/utils/specialites");
 
+// Keep the real (pure) expandQuery; stub getSynonymMap so it doesn't hit the DB
+// and doesn't consume a mockExecute value meant for the search_index/resume queries.
+vi.mock("./searchSynonyms", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./searchSynonyms")>();
+  return { ...actual, getSynonymMap: vi.fn() };
+});
+
 // Disable server-only for tests
 vi.mock("server-only", () => ({}));
 
@@ -70,6 +78,7 @@ describe("Search Engine (getSearchResults)", () => {
       spec.map((g: any) => ({ ...g, indicationsDetails: [] })),
     );
     vi.mocked(getResumeSpecsATCLabels).mockImplementation(async (spec) => spec);
+    vi.mocked(getSynonymMap).mockResolvedValue([]);
   });
 
   it("should return an empty array if the DB finds nothing", async () => {
@@ -205,6 +214,7 @@ describe("Search Engine (per-spécialité ranking)", () => {
       spec.map((g: any) => ({ ...g, indicationsDetails: [] })),
     );
     vi.mocked(getResumeSpecsATCLabels).mockImplementation(async (spec) => spec);
+    vi.mocked(getSynonymMap).mockResolvedValue([]);
   });
 
   it("ranks the variant whose name best matches the query above its siblings", async () => {
@@ -224,5 +234,34 @@ describe("Search Engine (per-spécialité ranking)", () => {
     expect(results).toHaveLength(2);
     expect(results[0].specId).toBe("CIS1000");
     expect(results[1].specId).toBe("CIS500");
+  });
+});
+
+describe("Search Engine (synonyms)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(formatSpecialitesResume).mockImplementation((spec) =>
+      spec.map((g: any) => ({ ...g, indicationsDetails: [] })),
+    );
+    vi.mocked(getResumeSpecsATCLabels).mockImplementation(async (spec) => spec);
+  });
+
+  it("expands a lay-term query to its canonical medical term and surfaces the indicated group", async () => {
+    vi.mocked(getSynonymMap).mockResolvedValue([
+      { id: 0, alias: "mal de tete", canonical: "céphalées" },
+    ]);
+    // The canonical term ("céphalées") hits an indication token in the index; the
+    // existing pipeline attaches the real, accented indication name as the match reason.
+    mockExecute.mockResolvedValueOnce([
+      { match_type: "indication", group_name: "DOLIPRANE", match_label: "Céphalées", token: "cephalees", spec_id: null, sml: 0.9 },
+    ]);
+    mockExecute.mockResolvedValueOnce([makeGroup("DOLIPRANE")]);
+
+    const results = await getSearchResults("mal de tête");
+
+    expect(getSynonymMap).toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0].groupName).toBe("DOLIPRANE");
+    expect(results[0].matchReasons).toEqual([{ type: "indication", label: "Céphalées" }]);
   });
 });

--- a/src/db/utils/search.ts
+++ b/src/db/utils/search.ts
@@ -8,6 +8,7 @@ import { unstable_cache } from "next/cache";
 import { getResumeSpecsATCLabels } from "@/db/utils/atc";
 import { formatSpecialitesResume } from "@/utils/specialites";
 import { computeSortScore } from "./searchScoring";
+import { expandQuery, getSynonymMap } from "./searchSynonyms";
 import { MatchReason, SearchResultItem } from "@/types/SearchTypes";
 
 
@@ -23,29 +24,42 @@ export const getSearchResults = unstable_cache(async function (
   // Normalize to lowercase+unaccented to match how tokens are stored in the index
   const normalizedQuery = query.toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
 
+  // Expand with curated synonyms: a lay term ("mal de tête") adds its canonical
+  // medical term ("céphalées") as an extra search term. Additive — no synonym match
+  // leaves terms = [normalizedQuery], i.e. unchanged behaviour.
+  const terms = expandQuery(normalizedQuery, await getSynonymMap());
+
+  // Each match's similarity is the best (GREATEST) word_similarity across all terms,
+  // so a synonym-driven hit scores against its canonical term, not the lay query.
+  const smlExpr = sql<number>`greatest(${sql.join(
+    terms.map((term) => sql`word_similarity(${term}, token)`),
+  )})`;
+
   const matches = (await db
     .selectFrom("search_index")
     .selectAll()
-    .select(({ fn, val }) => [
-      fn("word_similarity", [val(normalizedQuery), "token"]).as("sml"),
-    ])
+    .select(smlExpr.as("sml"))
     .where((eb) => {
-      if (normalizedQuery.length <= 3) {
-        // for very short queries, only match from the beginning to limit the number of results
-        // also, we only match specialities
-        return eb.and([
-          eb("token", "like", `${normalizedQuery}%`),
-          eb("match_type", "=", "name"),
+      // Same tiered matching as before, applied per term and OR-ed together.
+      const termPredicate = (term: string) => {
+        if (term.length <= 3) {
+          // for very short queries, only match from the beginning to limit the number of results
+          // also, we only match specialities
+          return eb.and([
+            eb("token", "like", `${term}%`),
+            eb("match_type", "=", "name"),
+          ]);
+        }
+        if (term.length <= 5) {
+          // if the query is short, we only do ilike search to avoid too many results
+          return eb("token", "like", `%${term}%`);
+        }
+        return eb.or([
+          sql<boolean>`token %> ${term}`, // fuzzy-search using pg_trgm
+          eb("token", "like", `%${term}%`), // exact match
         ]);
-      }
-      if (normalizedQuery.length <= 5) {
-        // if the query is short, we only do ilike search to avoid too many results
-        return eb("token", "like", `%${normalizedQuery}%`);
-      }
-      return eb.or([
-        sql<boolean>`token %> ${normalizedQuery}`, // fuzzy-search using pg_trgm
-        eb("token", "like", `%${normalizedQuery}%`), // exact match
-      ])
+      };
+      return eb.or(terms.map(termPredicate));
     })
     .orderBy("sml", "desc")
     .orderBy(({ fn }) => fn("length", ["token"]))

--- a/src/db/utils/searchSynonyms.test.ts
+++ b/src/db/utils/searchSynonyms.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+
+// expandQuery is pure, but importing the module also pulls in getSynonymMap
+// (db + next/cache), so stub those so the import succeeds.
+vi.mock("next/cache", () => ({ unstable_cache: (fn: any) => fn }));
+vi.mock("@/db", () => ({ default: {} }));
+
+import { expandQuery } from "./searchSynonyms";
+import { SearchSynonym } from "@/db/types";
+
+const syn = (alias: string, canonical: string): SearchSynonym => ({ id: 0, alias, canonical });
+
+describe("expandQuery", () => {
+  it("adds the canonical term for a single matching alias", () => {
+    const terms = expandQuery("mal de tete", [syn("mal de tete", "céphalées")]);
+    expect(terms).toEqual(["mal de tete", "cephalees"]);
+  });
+
+  it("matches a multi-word alias regardless of connector words", () => {
+    const terms = expandQuery("maux de tete", [syn("maux de tete", "céphalées")]);
+    expect(terms).toContain("cephalees");
+  });
+
+  it("tolerates French plurals on significant words via stem matching", () => {
+    const terms = expandQuery("maux de tetes", [syn("maux de tete", "céphalées")]);
+    expect(terms).toContain("cephalees");
+  });
+
+  it("returns the query unchanged when no alias matches", () => {
+    const terms = expandQuery("doliprane", [syn("mal de tete", "céphalées")]);
+    expect(terms).toEqual(["doliprane"]);
+  });
+
+  it("keeps the original query and adds the canonical when an alias is embedded in a longer query", () => {
+    const terms = expandQuery("doliprane mal de tete", [syn("mal de tete", "céphalées")]);
+    expect(terms).toEqual(["doliprane mal de tete", "cephalees"]);
+  });
+
+  it("dedupes canonical terms when several aliases map to the same term", () => {
+    const terms = expandQuery("mal de tete", [
+      syn("mal de tete", "céphalées"),
+      syn("mal de tete", "céphalées"),
+    ]);
+    expect(terms).toEqual(["mal de tete", "cephalees"]);
+  });
+});

--- a/src/db/utils/searchSynonyms.test.ts
+++ b/src/db/utils/searchSynonyms.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("next/cache", () => ({ unstable_cache: (fn: any) => fn }));
 vi.mock("@/db", () => ({ default: {} }));
 
-import { expandQuery } from "./searchSynonyms";
+import { expandQuery, matchedCanonicals } from "./searchSynonyms";
 import { SearchSynonym } from "@/db/types";
 
 const syn = (alias: string, canonical: string): SearchSynonym => ({ id: 0, alias, canonical });
@@ -42,5 +42,25 @@ describe("expandQuery", () => {
       syn("mal de tete", "céphalées"),
     ]);
     expect(terms).toEqual(["mal de tete", "cephalees"]);
+  });
+});
+
+describe("matchedCanonicals", () => {
+  it("returns the canonical term in its accented form when an alias matches", () => {
+    const terms = matchedCanonicals("mal de tete", [syn("mal de tete", "céphalées")]);
+    expect(terms).toEqual(["céphalées"]);
+  });
+
+  it("returns nothing when no alias matches", () => {
+    const terms = matchedCanonicals("doliprane", [syn("mal de tete", "céphalées")]);
+    expect(terms).toEqual([]);
+  });
+
+  it("dedupes by normalized form when several aliases map to the same canonical", () => {
+    const terms = matchedCanonicals("mal de tete", [
+      syn("mal de tete", "céphalées"),
+      syn("mal de tete", "Céphalées"),
+    ]);
+    expect(terms).toEqual(["céphalées"]);
   });
 });

--- a/src/db/utils/searchSynonyms.ts
+++ b/src/db/utils/searchSynonyms.ts
@@ -1,0 +1,61 @@
+import db from "@/db";
+import { unstable_cache } from "next/cache";
+import { SearchSynonym } from "@/db/types";
+
+// Same normalization as search.ts: lowercase + strip accents. Trim for safety.
+function normalize(str: string): string {
+  return str
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Mn}/gu, "")
+    .trim();
+}
+
+// Bidirectional stem match: true if either word is a prefix of the other.
+// Tolerates French plurals ("tetes" ~ "tete"). Min length 4 avoids short-word noise.
+function stemMatches(a: string, b: string): boolean {
+  const minLen = Math.min(a.length, b.length);
+  return minLen >= 4 && (a.startsWith(b) || b.startsWith(a));
+}
+
+// An alias word is "covered" by the query when the query contains it. Short connector
+// words (de, du, la, a, …) must match exactly; longer words tolerate plurals via stem match.
+function wordCovered(aliasWord: string, queryWords: string[]): boolean {
+  if (aliasWord.length < 4) return queryWords.includes(aliasWord);
+  return queryWords.some((qw) => stemMatches(qw, aliasWord));
+}
+
+function queryContainsAlias(queryWords: string[], aliasNormalized: string): boolean {
+  const aliasWords = aliasNormalized.split(/\s+/).filter(Boolean);
+  return aliasWords.length > 0 && aliasWords.every((aw) => wordCovered(aw, queryWords));
+}
+
+/**
+ * Expand a (normalized) query with the canonical terms of any matching synonym alias.
+ * Returns the original query plus deduped canonical terms (normalized for the index),
+ * original query first. Additive: a query that matches no alias is returned unchanged.
+ */
+export function expandQuery(normalizedQuery: string, synonyms: SearchSynonym[]): string[] {
+  const queryWords = normalize(normalizedQuery).split(/\s+/).filter(Boolean);
+  const terms = [normalizedQuery];
+  const seen = new Set([normalizedQuery]);
+  for (const syn of synonyms) {
+    if (queryContainsAlias(queryWords, normalize(syn.alias))) {
+      const term = normalize(syn.canonical);
+      if (term && !seen.has(term)) {
+        seen.add(term);
+        terms.push(term);
+      }
+    }
+  }
+  return terms;
+}
+
+// Small curated table — load all rows once and cache, like getSearchResults.
+export const getSynonymMap = unstable_cache(
+  async function (): Promise<SearchSynonym[]> {
+    return db.selectFrom("search_synonyms").selectAll().execute();
+  },
+  ["search-synonyms"],
+  { revalidate: 3600 },
+);

--- a/src/db/utils/searchSynonyms.ts
+++ b/src/db/utils/searchSynonyms.ts
@@ -30,25 +30,42 @@ function queryContainsAlias(queryWords: string[], aliasNormalized: string): bool
   return aliasWords.length > 0 && aliasWords.every((aw) => wordCovered(aw, queryWords));
 }
 
-/**
- * Expand a (normalized) query with the canonical terms of any matching synonym alias.
- * Returns the original query plus deduped canonical terms (normalized for the index),
- * original query first. Additive: a query that matches no alias is returned unchanged.
- */
+// Synonyms whose alias phrase is present in the query.
+function matchingSynonyms(query: string, synonyms: SearchSynonym[]): SearchSynonym[] {
+  const queryWords = normalize(query).split(/\s+/).filter(Boolean);
+  return synonyms.filter((syn) => queryContainsAlias(queryWords, normalize(syn.alias)));
+}
+
+// Expand a (normalized) query with the canonical terms of any matching synonym alias.
+// Returns the original query plus deduped canonical terms (normalized for the index),
+// original query first. Additive: a query that matches no alias is returned unchanged.
 export function expandQuery(normalizedQuery: string, synonyms: SearchSynonym[]): string[] {
-  const queryWords = normalize(normalizedQuery).split(/\s+/).filter(Boolean);
   const terms = [normalizedQuery];
   const seen = new Set([normalizedQuery]);
-  for (const syn of synonyms) {
-    if (queryContainsAlias(queryWords, normalize(syn.alias))) {
-      const term = normalize(syn.canonical);
-      if (term && !seen.has(term)) {
-        seen.add(term);
-        terms.push(term);
-      }
+  for (const syn of matchingSynonyms(normalizedQuery, synonyms)) {
+    const term = normalize(syn.canonical);
+    if (term && !seen.has(term)) {
+      seen.add(term);
+      terms.push(term);
     }
   }
   return terms;
+}
+
+// Canonical terms of the synonyms a query triggered, in their original accented form
+// (deduped) — for displaying a "Vouliez-vous dire : …" mention. Empty when no alias matched.
+export function matchedCanonicals(query: string, synonyms: SearchSynonym[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const syn of matchingSynonyms(query, synonyms)) {
+    const display = syn.canonical.trim();
+    const key = normalize(display);
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      out.push(display);
+    }
+  }
+  return out;
 }
 
 // Small curated table — load all rows once and cache, like getSearchResults.
@@ -59,3 +76,10 @@ export const getSynonymMap = unstable_cache(
   ["search-synonyms"],
   { revalidate: 3600 },
 );
+
+// Canonical medical terms a (raw) query triggered via synonyms, for the
+// "Vouliez-vous dire : …" mention. Empty unless an alias actually matched.
+export async function getSynonymSuggestion(query: string): Promise<string[]> {
+  if (!query || !query.trim()) return [];
+  return matchedCanonicals(query, await getSynonymMap());
+}


### PR DESCRIPTION
  Searching a lay term like "mal de tête" returned nothing for the medical
  term "céphalées", even though the indication is already in the index. Add a
  hand-curated synonym layer on top of the existing pg_trgm search.

  - migration: new search_synonyms table (alias, canonical) + index on alias
  - searchSynonyms.ts: cached getSynonymMap() + expandQuery() — multi-word and FR-plural alias matching (ported from the POC's searchIntent.ts)
  - search.ts: expand the query with matching canonical terms and search the index over all terms (OR-ed tiered predicate); sml is now the GREATEST word_similarity across terms, so a synonym hit scores against its canonical term, not the lay query. Additive — queries with no alias are unchanged
  - syncWithGrist: sync search_synonyms from Grist; a comma-separated Alias cell expands to one row per alias. syncTable mappers may now return an array
  - tests: expandQuery unit tests + a synonym case in search.test.ts

  Canonical matches surface as indication-type hits, so they rank below direct
  name/substance matches and reuse the existing "indiqué pour" match reason.

  Requires db:migrate:latest + db:sync-grist to populate the table.