### PR TITLE
fix: batch populateSpecMetadataTable to avoid OOM on Scalingo

### DIFF
--- a/esbuild.scripts.mjs
+++ b/esbuild.scripts.mjs
@@ -4,6 +4,7 @@ await build({
   entryPoints: [
     "scripts/aggregatePathoClasseClinique.ts",
     "scripts/importNoticeRCP.ts",
+    "scripts/populateSpecMetadataTable.ts",
     "scripts/seedInteractionsSearch.ts",
     "scripts/seedReviewApp.ts",
     "scripts/seedSearchIndex.ts",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "db:update-resume": "npx tsx scripts/updateResumeData.ts",
     "db:seed-search-index": "npx tsx scripts/seedSearchIndex.ts",
     "db:seed-review-app": "node .next/standalone/scripts/seedReviewApp.js",
+    "db:populate-spec-metadata": "node .next/standalone/scripts/populateSpecMetadataTable.js",
     "db:seed-interactions": "npx tsx scripts/seedInteractionsSearch.ts",
     "db:indications": "npx tsx scripts/aggregatePathoClasseClinique.ts"
   },

--- a/scripts/populateSpecMetadataTable.ts
+++ b/scripts/populateSpecMetadataTable.ts
@@ -1,47 +1,15 @@
 import db from "@/db";
 import { Specialite } from "@/db/pdbmMySQL/types";
-import { NoticeContentDB, NoticeDB, SpecialiteMetadata } from "@/db/types";
-import { getAllNoticesContent, getAllNoticesWithoutChildren } from "@/db/utils/notice";
+import { NoticeDB, SpecialiteMetadata } from "@/db/types";
+import { getAllNoticesWithoutChildren, getIndicationsText } from "@/db/utils/notice";
 import { getAllSpecialites } from "@/db/utils/specialities";
-import { NoticeData, NoticeRCPContentBlock } from "@/types/SpecialiteTypes";
-import { formatNoticeDateNotif, getIndicationsBlock } from "@/utils/notices";
 
 //npx tsx scripts/populateSpecMetadataTable.ts
 
-function getChildrenText(children: NoticeRCPContentBlock[]): string {
-  let desc: string = "";
-  children.forEach((block: NoticeRCPContentBlock) => {
-    if(block.content) {
-      desc += (desc !== "" ? " " : "") + block.content.join(" ");
-    }
-    if(block.children) {
-      desc += (desc !== "" ? " " : "") + getChildrenText(block.children);
-    }
-  });
-  return desc;
-}
-
-function getNoticeChildren(children: number[], noticeContent: NoticeContentDB[]): NoticeRCPContentBlock[] {
-  const childrenContent: NoticeRCPContentBlock[] = [];
-  children.forEach((child) => {
-    const contentData = noticeContent.find((content) => content.id === child);
-    if(contentData) {
-      childrenContent.push({
-        id: contentData.id,
-        type: contentData.type,
-        styles: contentData.styles,
-        anchor: contentData.anchor,
-        content: contentData.content,
-        children: (contentData.children && contentData.children.length > 0) 
-          ? getNoticeChildren(contentData.children, noticeContent) : [],
-        tag: contentData.tag,
-        rowspan: contentData.rowspan,
-        colspan: contentData.colspan,
-      });
-    }
-  });
-  return childrenContent;
-}
+// Process notices in batches so we never hold the whole notices_content table
+// in memory (that load was the source of the OOM on Scalingo).
+const NOTICE_BATCH_SIZE = 50;
+const INSERT_CHUNK_SIZE = 500;
 
 export async function populateSpecMetadataTable(): Promise<void> {
   await db
@@ -50,43 +18,65 @@ export async function populateSpecMetadataTable(): Promise<void> {
 
   const allSpecialites: Specialite[] = await getAllSpecialites();
   const allNotices: NoticeDB[] = await getAllNoticesWithoutChildren();
-  const allNoticesContent: NoticeContentDB[] = await getAllNoticesContent();
 
-  const specMetadata: SpecialiteMetadata[] = [];
-  allSpecialites.forEach((spec: Specialite) => {
-    const noticeDB = allNotices.find((notice: NoticeDB) => notice.codeCIS.toString() === spec.SpecId.trim());
-    
-    if(noticeDB) {
-      //We don't really need of the formatted notice date but trying to keep it right for the future
-      const noticeData: NoticeData = {
-        codeCIS: noticeDB.codeCIS,
-        title: noticeDB.title,
-        dateNotif: formatNoticeDateNotif(noticeDB.dateNotif),
-        children: (noticeDB.children && noticeDB.children.length > 0) 
-          ? getNoticeChildren(noticeDB.children, allNoticesContent) : [],
-      }
-      let desc = "";
-      const indicationsBlock = getIndicationsBlock(noticeData);
-      if(indicationsBlock && indicationsBlock.children){
-        desc = getChildrenText(indicationsBlock.children);
-      }
-      const metadata = {
-        CIS: noticeData.codeCIS,
-        title: spec.SpecDenom01,
-        description: desc,
-      };
-      specMetadata.push(metadata);
-    }
+  // Notices carry their top-level children ids but no content text, so this map
+  // is cheap to keep around.
+  const noticeByCIS = new Map<string, NoticeDB>(
+    allNotices.map((notice) => [notice.codeCIS.toString(), notice]),
+  );
+
+  // Only the specialites that have a matching notice get a metadata row.
+  const specsWithNotice = allSpecialites.flatMap((spec) => {
+    const noticeDB = noticeByCIS.get(spec.SpecId.trim());
+    return noticeDB ? [{ spec, noticeDB }] : [];
   });
 
-  const result = await db
-    .insertInto('specialites_metadata')
-    .values(specMetadata)
-    .execute();
-  console.log(`Nombre de specialites ajoutées: ${result[0].numInsertedOrUpdatedRows}`);
+  let buffer: SpecialiteMetadata[] = [];
+  let totalInserted = 0;
+
+  const flush = async () => {
+    if (buffer.length === 0) return;
+    await db
+      .insertInto('specialites_metadata')
+      .values(buffer)
+      .execute();
+    totalInserted += buffer.length;
+    buffer = [];
+  };
+
+  for (let i = 0; i < specsWithNotice.length; i += NOTICE_BATCH_SIZE) {
+    const batch = specsWithNotice.slice(i, i + NOTICE_BATCH_SIZE);
+
+    const metadatas = await Promise.all(
+      batch.map(async ({ spec, noticeDB }) => {
+        const description =
+          noticeDB.children && noticeDB.children.length > 0
+            ? await getIndicationsText(noticeDB.children)
+            : "";
+        return {
+          CIS: noticeDB.codeCIS,
+          title: spec.SpecDenom01,
+          description,
+        };
+      }),
+    );
+
+    buffer.push(...metadatas);
+    if (buffer.length >= INSERT_CHUNK_SIZE) await flush();
+  }
+
+  await flush();
+
+  console.log(`Nombre de specialites ajoutées: ${totalInserted}`);
 }
 
-populateSpecMetadataTable().finally(async () => {
-  await db.destroy();
-  process.exit(0);
-});
+populateSpecMetadataTable()
+  .then(() => process.exitCode = 0)
+  .catch((err) => {
+    console.error("populateSpecMetadataTable failed:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.destroy();
+    process.exit(process.exitCode ?? 0);
+  });

--- a/src/db/utils/notice.ts
+++ b/src/db/utils/notice.ts
@@ -2,7 +2,7 @@
 
 import db from '@/db';
 import { NoticeData, NoticeRCPContentBlock } from '@/types/SpecialiteTypes';
-import { NoticeContentDB, NoticeDB } from '../types';
+import { NoticeDB } from '../types';
 import { formatNoticeDateNotif } from '@/utils/notices';
 
 async function getContent(children: number[]): Promise<any[]>{
@@ -65,9 +65,54 @@ export async function getAllNoticesWithoutChildren(): Promise<NoticeDB[]> {
     .execute();
 };
 
-export async function getAllNoticesContent(): Promise<NoticeContentDB[]> {
-  return await db
-    .selectFrom("notices_content")
-    .selectAll()
-    .execute();
+// Returns the plain text of a notice's "indications" section (anchor
+// "Ann3bQuestceque"), given the notice's top-level content-block ids.
+// Only that subtree is loaded — one query per tree depth — so memory stays
+// bounded to a single notice instead of the whole notices_content table.
+export async function getIndicationsText(noticeChildrenIds: number[]): Promise<string> {
+  if (!noticeChildrenIds || noticeChildrenIds.length === 0) return "";
+
+  const fetchBlocks = (ids: number[]) =>
+    db
+      .selectFrom("notices_content")
+      .select(["id", "anchor", "content", "children"])
+      .where("id", "in", ids)
+      .execute();
+
+  const topLevel = await fetchBlocks(noticeChildrenIds);
+  const indicationsBlock = topLevel.find((b) => b.anchor === "Ann3bQuestceque");
+  if (!indicationsBlock?.children || indicationsBlock.children.length === 0) return "";
+
+  // Load the whole indications subtree, one depth level per query.
+  const byId = new Map<number, { content?: string[]; children?: number[] }>();
+  let frontier = indicationsBlock.children;
+  while (frontier.length > 0) {
+    const rows = await fetchBlocks(frontier);
+    const next: number[] = [];
+    for (const row of rows) {
+      if (row.id == null) continue;
+      byId.set(row.id, { content: row.content, children: row.children });
+      if (row.children && row.children.length > 0) next.push(...row.children);
+    }
+    frontier = next;
+  }
+
+  // Depth-first text assembly: a block's own content, then its descendants.
+  const assemble = (ids: number[]): string => {
+    let desc = "";
+    ids.forEach((id) => {
+      const block = byId.get(id);
+      if (!block) return;
+      if (block.content && block.content.length > 0) {
+        desc += (desc !== "" ? " " : "") + block.content.join(" ");
+      }
+      if (block.children && block.children.length > 0) {
+        const childText = assemble(block.children);
+        if (childText) desc += (desc !== "" ? " " : "") + childText;
+      }
+    });
+    return desc;
+  };
+
+  return assemble(indicationsBlock.children);
 };


### PR DESCRIPTION
The script loaded the entire notices_content table into memory via getAllNoticesContent() and rebuilt each notice's full content tree just to keep its indications section, which OOM'd even on the largest machine.
 - Replace getAllNoticesContent() with getIndicationsText(), which loads only a single notice's indications subtree (anchor "Ann3bQuestceque"), one query per tree depth, keeping memory bounded per notice.
- Rewrite the script to process specialites in batches (50) and insert metadata in chunks (500) instead of one full-corpus array + single insert.
- Surface failures: add a .catch so an error no longer silently exits 0.
- Bundle the script in the build (esbuild.scripts.mjs) and add the db:populate-spec-metadata npm alias