### PR TITLE
fix: when metadata not found

### DIFF
--- a/scripts/populateSpecMetadataTable.ts
+++ b/scripts/populateSpecMetadataTable.ts
@@ -25,12 +25,6 @@ export async function populateSpecMetadataTable(): Promise<void> {
     allNotices.map((notice) => [notice.codeCIS.toString(), notice]),
   );
 
-  // Only the specialites that have a matching notice get a metadata row.
-  const specsWithNotice = allSpecialites.flatMap((spec) => {
-    const noticeDB = noticeByCIS.get(spec.SpecId.trim());
-    return noticeDB ? [{ spec, noticeDB }] : [];
-  });
-
   let buffer: SpecialiteMetadata[] = [];
   let totalInserted = 0;
 
@@ -44,17 +38,19 @@ export async function populateSpecMetadataTable(): Promise<void> {
     buffer = [];
   };
 
-  for (let i = 0; i < specsWithNotice.length; i += NOTICE_BATCH_SIZE) {
-    const batch = specsWithNotice.slice(i, i + NOTICE_BATCH_SIZE);
+  // Add metadata informations for all notices even if no indications text
+  for (let i = 0; i < allSpecialites.length; i += NOTICE_BATCH_SIZE) {
+    const batch = allSpecialites.slice(i, i + NOTICE_BATCH_SIZE);
 
     const metadatas = await Promise.all(
-      batch.map(async ({ spec, noticeDB }) => {
+      batch.map(async (spec) => {
+        const noticeDB = noticeByCIS.get(spec.SpecId.trim());
         const description =
-          noticeDB.children && noticeDB.children.length > 0
+          noticeDB && noticeDB.children && noticeDB.children.length > 0
             ? await getIndicationsText(noticeDB.children)
             : "";
         return {
-          CIS: noticeDB.codeCIS,
+          CIS: Number(spec.SpecId.trim()),
           title: spec.SpecDenom01,
           description,
         };

--- a/src/app/(container)/atc/[code]/page.tsx
+++ b/src/app/(container)/atc/[code]/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata(
 
   if (!atc1 && !atc2){
     return {
-      title: `Classe de médicaments - ${(await parent).title?.absolute}`,
+      title: `Classe de médicaments ${code} - ${(await parent).title?.absolute}`,
     };
   }
   let title = "";

--- a/src/app/(container)/atc/[code]/page.tsx
+++ b/src/app/(container)/atc/[code]/page.tsx
@@ -29,7 +29,11 @@ export async function generateMetadata(
   const atc1 = await getAtc1(code);
   const atc2 = code.length === 3 ? await getAtc2(code) : undefined;
 
-  if (!atc1 && !atc2) notFound();
+  if (!atc1 && !atc2){
+    return {
+      title: `Classe de médicaments - ${(await parent).title?.absolute}`,
+    };
+  }
   let title = "";
   if(atc2) {
     title += atc2.label + (atc1 && ' - ');

--- a/src/app/(container)/indications/[code]/page.tsx
+++ b/src/app/(container)/indications/[code]/page.tsx
@@ -21,7 +21,11 @@ export async function generateMetadata(
 
   const { code } = await props.params;
   const indication: Indication | undefined = await getIndications(Number(code));
-  if (!indication) return notFound();
+  if (!indication){
+    return {
+      title: `Indication - ${(await parent).title?.absolute}`,
+    };
+  }
 
   return {
     title: `${indication.nom} - ${(await parent).title?.absolute}`,

--- a/src/app/(container)/indications/[code]/page.tsx
+++ b/src/app/(container)/indications/[code]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata(
   const indication: Indication | undefined = await getIndications(Number(code));
   if (!indication){
     return {
-      title: `Indication - ${(await parent).title?.absolute}`,
+      title: `Indication ${code}- ${(await parent).title?.absolute}`,
     };
   }
 

--- a/src/app/(container)/medicaments/[CIS]/page.tsx
+++ b/src/app/(container)/medicaments/[CIS]/page.tsx
@@ -98,7 +98,12 @@ export async function generateMetadata(
   const { CIS } = await props.params;
 
   const metadata = await getSpecialiteMetadata(Number(CIS.trim()));
-  if(!metadata) return notFound();
+
+  if (!metadata) {
+    return {
+      title: 'Médicament',
+    };
+  }
 
   const name = formatSpecName(metadata.title);
   return {

--- a/src/app/(container)/medicaments/[CIS]/page.tsx
+++ b/src/app/(container)/medicaments/[CIS]/page.tsx
@@ -101,7 +101,7 @@ export async function generateMetadata(
 
   if (!metadata) {
     return {
-      title: 'Médicament',
+      title: `Médicament ${CIS}`,
     };
   }
 

--- a/src/app/(container)/substances/[id]/page.tsx
+++ b/src/app/(container)/substances/[id]/page.tsx
@@ -22,7 +22,11 @@ export async function generateMetadata(
   const { id } = await props.params;
   const ids = decodeURIComponent(id).split(",");//NomId
   const substances: SubstanceNom[] = await getSubstances(ids) ?? [];
-  if (substances.length < ids.length) return notFound();
+  if (substances.length < ids.length) {
+    return {
+      title: 'Substance',
+    };
+  }
 
   const definitionsRaw = await getSubstanceDefinition(ids, substances.map((subs) => subs.SubsId.trim()));
   const definitionString = definitionsRaw.map(d => `${d.SA} : ${d.Definition}`).join(" - ")

--- a/src/app/(container)/substances/[id]/page.tsx
+++ b/src/app/(container)/substances/[id]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(
   const substances: SubstanceNom[] = await getSubstances(ids) ?? [];
   if (substances.length < ids.length) {
     return {
-      title: 'Substance',
+      title: `Substance ${id}`,
     };
   }
 


### PR DESCRIPTION
Two problems : 
- When metadata are not found, "not found" is returned, so the page is not displayed
- For speciality without notice, the metadata were not added in DB, but there is still the title to add


---
Staging & production : 
- relancer le script db:populate-spec-metadata