### PR TITLE
fix: add "use client" in all client components to prevent errors

### DIFF
--- a/src/components/GenericAccordion.tsx
+++ b/src/components/GenericAccordion.tsx
@@ -1,5 +1,6 @@
+"use client";
+
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
-import React from "react";
 
 export default function GenericAccordion({
   className,

--- a/src/components/articles/ArticlesResumeList.tsx
+++ b/src/components/articles/ArticlesResumeList.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 import { useIsDark } from "@codegouvfr/react-dsfr/useIsDark";

--- a/src/components/definition/ATC1DefinitionContent.tsx
+++ b/src/components/definition/ATC1DefinitionContent.tsx
@@ -1,4 +1,6 @@
-import React, { HTMLAttributes } from "react";
+"use client";
+
+import { HTMLAttributes } from "react";
 import { AdvancedATCClass, DataTypeEnum } from "@/types/DataTypes";
 import { ArticleCardResume } from "@/types/ArticlesTypes";
 import PageDefinitionContent from "./PageDefinitionContent";

--- a/src/components/definition/ATC2DefinitionContent.tsx
+++ b/src/components/definition/ATC2DefinitionContent.tsx
@@ -1,4 +1,6 @@
-import React, { HTMLAttributes } from "react";
+"use client";
+
+import { HTMLAttributes } from "react";
 import { DataTypeEnum } from "@/types/DataTypes";
 import { ArticleCardResume } from "@/types/ArticlesTypes";
 import PageDefinitionContent from "./PageDefinitionContent";

--- a/src/components/definition/IndicationDefinitionContent.tsx
+++ b/src/components/definition/IndicationDefinitionContent.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes } from "react";
 import { DataTypeEnum } from "@/types/DataTypes";
 import { ArticleCardResume } from "@/types/ArticlesTypes";

--- a/src/components/definition/SubstanceDefinitionContent.tsx
+++ b/src/components/definition/SubstanceDefinitionContent.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { HTMLAttributes } from "react";
 import { DataTypeEnum } from "@/types/DataTypes";
 import { ArticleCardResume } from "@/types/ArticlesTypes";

--- a/src/components/marr/MarrNoticeAdvanced.tsx
+++ b/src/components/marr/MarrNoticeAdvanced.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 import Link from "next/link";

--- a/src/components/marr/MarrResumeList.tsx
+++ b/src/components/marr/MarrResumeList.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes } from "react";
 import { fr } from "@codegouvfr/react-dsfr"; 
 import { useIsDark } from "@codegouvfr/react-dsfr/useIsDark";

--- a/src/components/medicaments/notice/PresentationsList.tsx
+++ b/src/components/medicaments/notice/PresentationsList.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   PresentationComm,
   PresentationStat,

--- a/src/components/medicaments/notice/QuestionKeyword.tsx
+++ b/src/components/medicaments/notice/QuestionKeyword.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 function QuestionKeyword({
   keyword,
   questionId,

--- a/src/components/medicamentsGeneriques/MedicamentGeneriqueContainer.tsx
+++ b/src/components/medicamentsGeneriques/MedicamentGeneriqueContainer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes } from "react";
 import ContentContainer from "../generic/ContentContainer";
 import { fr } from "@codegouvfr/react-dsfr";

--- a/src/components/rating/RatingAdvanced.tsx
+++ b/src/components/rating/RatingAdvanced.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes, useEffect, useState } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 import Button from "@codegouvfr/react-dsfr/Button";

--- a/src/components/rating/RatingStars.tsx
+++ b/src/components/rating/RatingStars.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes, useEffect, useState } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 

--- a/src/components/tags/ClassTag.tsx
+++ b/src/components/tags/ClassTag.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
 import { HTMLAttributes } from "react";

--- a/src/components/tags/GenericPrincepsTag.tsx
+++ b/src/components/tags/GenericPrincepsTag.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import { HTMLAttributes } from "react";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";

--- a/src/components/tags/MatchReasonTags.tsx
+++ b/src/components/tags/MatchReasonTags.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import { fr } from "@codegouvfr/react-dsfr";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";

--- a/src/components/tags/PediatricsTags.tsx
+++ b/src/components/tags/PediatricsTags.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import { HTMLAttributes } from "react";
 import type { FrIconClassName } from "@codegouvfr/react-dsfr/src/fr/generatedFromCss/classNames";

--- a/src/components/tags/PregnancyMentionTag.tsx
+++ b/src/components/tags/PregnancyMentionTag.tsx
@@ -2,7 +2,7 @@
 
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import type { FrIconClassName } from "@codegouvfr/react-dsfr/src/fr/generatedFromCss/classNames";
-import React, { HTMLAttributes } from "react";
+import { HTMLAttributes } from "react";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
 import { fr } from "@codegouvfr/react-dsfr";
 import "./dsfr-custom-tags.css";

--- a/src/components/tags/PregnancyPlanTag.tsx
+++ b/src/components/tags/PregnancyPlanTag.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import type { FrIconClassName } from "@codegouvfr/react-dsfr/src/fr/generatedFromCss/classNames";
-import React, { HTMLAttributes } from "react";
+import { HTMLAttributes } from "react";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
 import { fr } from "@codegouvfr/react-dsfr";
 import "./dsfr-custom-tags.css";

--- a/src/components/tags/PrescriptionTag.tsx
+++ b/src/components/tags/PrescriptionTag.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import { HTMLAttributes } from "react";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";

--- a/src/components/tags/SubstanceTag.tsx
+++ b/src/components/tags/SubstanceTag.tsx
@@ -1,8 +1,10 @@
+"use client";
+
 import { SpecComposant, SubstanceNom } from "@/db/pdbmMySQL/types";
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import { displaySimpleComposants } from "@/displayUtils";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
-import React, { HTMLAttributes } from "react";
+import { HTMLAttributes } from "react";
 import "./dsfr-custom-tags.css";
 import { trackEvent } from "@/services/tracking";
 


### PR DESCRIPTION
Fatal error on a generic page (generiques/69978246 for instance) caused by the absence of "use client" in the header of a client component.
Solution : add "use client" to all client components to fix this error and prevent future ones