### PR TITLE
mod(autocomplete): dedicated autocomplete endpoint and logic

### DIFF
--- a/src/app/(container)/page.tsx
+++ b/src/app/(container)/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { fr } from "@codegouvfr/react-dsfr";
-import AutocompleteSearch from "@/components/AutocompleteSearch";
+import AutocompleteSearch from "@/components/search/autocomplete/AutocompleteSearch";
 import { getArticles } from "@/db/utils/articles";
 import { getMarketedMedicamentCount } from "@/db/utils/specialities";
 import ArticlesSimpleList from "@/components/articles/ArticlesSimpleList";

--- a/src/app/(container)/rechercher/autocomplete/route.ts
+++ b/src/app/(container)/rechercher/autocomplete/route.ts
@@ -1,0 +1,15 @@
+import { getAutocompleteSuggestions } from "@/db/utils";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const search = searchParams.get("s");
+  if (!search) {
+    return NextResponse.json(
+      { error: "Missing search parameter" },
+      { status: 400 },
+    );
+  }
+  const results = await getAutocompleteSuggestions(search);
+  return NextResponse.json(results);
+}

--- a/src/components/ClientHeader.tsx
+++ b/src/components/ClientHeader.tsx
@@ -2,7 +2,7 @@
 
 import { Header } from "@codegouvfr/react-dsfr/Header";
 import Image from "next/image";
-import { AutocompleteSearchInput } from "@/components/AutocompleteSearch";
+import { AutocompleteSearchInput } from "@/components/search/autocomplete/AutocompleteSearch";
 import { useRouter } from "next/navigation";
 import { useIsDark } from "@codegouvfr/react-dsfr/useIsDark";
 import { useTracking } from "@/services/tracking";

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -2,7 +2,7 @@
 
 import { fr } from "@codegouvfr/react-dsfr";
 import styled from "styled-components";
-import AutocompleteSearch from "@/components/AutocompleteSearch";
+import AutocompleteSearch from "@/components/search/autocomplete/AutocompleteSearch";
 import ContentContainer from "@/components/generic/ContentContainer";
 import SearchResultsList from "@/components/search/SearchResultsList";
 import { HTMLAttributes } from "react";

--- a/src/components/search/autocomplete/AutocompleteSearch.test.tsx
+++ b/src/components/search/autocomplete/AutocompleteSearch.test.tsx
@@ -13,25 +13,37 @@ vi.mock("@/services/tracking", () => ({
   trackSearchEvent: vi.fn(),
 }));
 
-const mockSearchResults = [
+const mockAutocompleteSections = [
   {
-    groupName: "DOLIPRANE",
-    specName: "DOLIPRANE 1000 mg",
-    specId: "61234567",
-    composants: "paracetamol",
-    specialites: [],
-    indicationsIds: [],
-    CISList: [],
-    subsIds: [],
-    matchReasons: [],
-    shortSpecialites: [],
-    score: 5,
+    type: "substance",
+    title: "Substances actives",
+    items: [
+      {
+        type: "substance",
+        label: "Paracétamol",
+        href: "/substances/123",
+        score: 300,
+      },
+    ],
+  },
+  {
+    type: "specialite",
+    title: "Médicaments",
+    items: [
+      {
+        type: "specialite",
+        label: "Doliprane 1000 mg",
+        href: "/medicaments/61234567",
+        matchReasons: [{ type: "substance", label: "Paracétamol" }],
+        score: 5,
+      },
+    ],
   },
 ];
 
-// Mock SWR to return our mock search results
+// Mock SWR to return our mock autocomplete sections
 vi.mock("swr", () => ({
-  default: () => ({ data: mockSearchResults }),
+  default: () => ({ data: mockAutocompleteSections }),
 }));
 
 describe("AutocompleteSearchInput", () => {
@@ -51,32 +63,32 @@ describe("AutocompleteSearchInput", () => {
     );
   }
 
-  it("should navigate to search page when selecting a group name", () => {
+  it("should navigate to the suggestion href", () => {
     renderAutocomplete();
     const input = screen.getByRole("combobox");
-    fireEvent.change(input, { target: { value: "dolip" } });
+    fireEvent.change(input, { target: { value: "para" } });
 
     const option = screen
       .getAllByRole("option")
-      .find((o) => o.textContent === "Doliprane")!;
+      .find((o) => o.textContent === "Paracétamol")!;
     fireEvent.mouseDown(option);
 
-    expect(mockPush).toHaveBeenCalledWith("/rechercher?s=Doliprane");
+    expect(mockPush).toHaveBeenCalledWith("/substances/123");
   });
 
-  it("should call onSearch for group name when onSearch is provided", () => {
+  it("should navigate to the suggestion href even when onSearch is provided", () => {
     const onSearch = vi.fn();
     renderAutocomplete(onSearch);
     const input = screen.getByRole("combobox");
-    fireEvent.change(input, { target: { value: "dolip" } });
+    fireEvent.change(input, { target: { value: "para" } });
 
     const option = screen
       .getAllByRole("option")
-      .find((o) => o.textContent === "Doliprane")!;
+      .find((o) => o.textContent === "Paracétamol")!;
     fireEvent.mouseDown(option);
 
-    expect(onSearch).toHaveBeenCalledWith("Doliprane");
-    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/substances/123");
+    expect(onSearch).not.toHaveBeenCalled();
   });
 
   it("should not show dropdown before user types", () => {
@@ -102,10 +114,10 @@ describe("AutocompleteSearchInput", () => {
   it("should select highlighted option on Enter", () => {
     renderAutocomplete();
     const input = screen.getByRole("combobox");
-    fireEvent.change(input, { target: { value: "doli" } });
+    fireEvent.change(input, { target: { value: "para" } });
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(mockPush).toHaveBeenCalledWith("/rechercher?s=Doliprane");
+    expect(mockPush).toHaveBeenCalledWith("/substances/123");
   });
 
   it("should close dropdown on Escape", () => {
@@ -124,7 +136,7 @@ describe("AutocompleteSearchInput", () => {
 
     const option = screen
       .getAllByRole("option")
-      .find((o) => o.textContent === "Doliprane 1000 mg")!;
+      .find((o) => o.textContent?.includes("Doliprane 1000 mg"))!;
     fireEvent.mouseDown(option);
 
     expect(mockPush).toHaveBeenCalledWith("/medicaments/61234567");
@@ -138,10 +150,19 @@ describe("AutocompleteSearchInput", () => {
 
     const option = screen
       .getAllByRole("option")
-      .find((o) => o.textContent === "Doliprane 1000 mg")!;
+      .find((o) => o.textContent?.includes("Doliprane 1000 mg"))!;
     fireEvent.mouseDown(option);
 
     expect(mockPush).toHaveBeenCalledWith("/medicaments/61234567");
     expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it("should display sections and match reasons", () => {
+    renderAutocomplete();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "para" } });
+
+    expect(screen.getByText("Substances actives")).toBeDefined();
+    expect(screen.getByText("Médicaments")).toBeDefined();
+    expect(screen.getByText("contient Paracétamol")).toBeDefined();
   });
 });

--- a/src/components/search/autocomplete/AutocompleteSearch.tsx
+++ b/src/components/search/autocomplete/AutocompleteSearch.tsx
@@ -2,20 +2,12 @@
 
 import { fr } from "@codegouvfr/react-dsfr";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
-import { useState } from "react";
-import { formatSpecName } from "@/displayUtils";
+import { useMemo, useState } from "react";
 import { SearchBar } from "@codegouvfr/react-dsfr/SearchBar";
 import useSWR from "swr";
 import { useRouter } from "next/navigation";
 import { trackSearchEvent } from "@/services/tracking";
-import { SearchResultItem } from "@/types/SearchTypes";
-
-type AutocompleteOption = {
-  label: string;
-  type: "group" | "specialite";
-  specId?: string;
-  score: number;
-};
+import { AutocompleteSection, AutocompleteSuggestion, MatchReason } from "@/types/SearchTypes";
 
 type SearchInputProps = {
   name: string;
@@ -27,6 +19,16 @@ type SearchInputProps = {
   onSearch?: (search: string) => void;
 };
 
+function formatMatchReason(matchReasons?: MatchReason[]): string | undefined {
+  const substanceReason = matchReasons?.find((reason) => reason.type === "substance");
+  if (substanceReason) return `contient ${substanceReason.label}`;
+
+  const indicationReason = matchReasons?.find((reason) => reason.type === "indication");
+  if (indicationReason) return `lié à ${indicationReason.label}`;
+
+  return undefined;
+}
+
 export function AutocompleteSearchInput({
   name,
   initialValue,
@@ -34,7 +36,6 @@ export function AutocompleteSearchInput({
   id,
   placeholder,
   type,
-  onSearch,
 }: SearchInputProps) {
 
   const router = useRouter();
@@ -42,10 +43,10 @@ export function AutocompleteSearchInput({
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
 
-  const { data: searchResults } = useSWR(
+  const { data: autocompleteSections } = useSWR(
     inputValue ?? null,
     async (search) =>
-      fetch(`/rechercher/results?s=${encodeURIComponent(search)}`, {
+      fetch(`/rechercher/autocomplete?s=${encodeURIComponent(search)}`, {
         cache: "force-cache",
       }).then((res) => res.json()),
     {
@@ -54,57 +55,27 @@ export function AutocompleteSearchInput({
       revalidateOnReconnect: false,
       fallbackData: [],
     },
-  ) as { data: SearchResultItem[] };
+  ) as { data: AutocompleteSection[] };
 
-  // Build a mixed list: each spécialité (→ medicament page) plus its generic group
-  // (→ full search page). The group entry is kept so users can still browse all variants.
-  const options: AutocompleteOption[] = (() => {
-    if (!searchResults) return [];
-    const specOptions: AutocompleteOption[] = [];
-    const groupScores = new Map<string, number>();
-    for (const result of searchResults) {
-      if (result.specName && result.specId) {
-        specOptions.push({
-          label: formatSpecName(result.specName),
-          type: "specialite",
-          specId: result.specId,
-          score: result.score,
-        });
-      }
-      if (result.groupName) {
-        const groupLabel = formatSpecName(result.groupName);
-        groupScores.set(groupLabel, Math.max(groupScores.get(groupLabel) ?? 0, result.score));
-      }
-    }
-    const groupOptions: AutocompleteOption[] = [...groupScores.entries()].map(
-      ([label, score]) => ({ label, type: "group", score }),
-    );
-    return [...groupOptions, ...specOptions]
-      .sort((a, b) => {
-        if (b.score !== a.score) return b.score - a.score;
-        // on a tie, surface the group entry above its variants
-        if (a.type !== b.type) return a.type === "group" ? -1 : 1;
-        return a.label.localeCompare(b.label, "fr");
-      })
-      .filter((opt, i, arr) => arr.findIndex((o) => o.type === opt.type && o.label === opt.label) === i)
-      .slice(0, 10);
-  })();
+  const options = useMemo(
+    () => (autocompleteSections ?? []).flatMap((section) => (
+      section.items
+    )),
+    [autocompleteSections],
+  );
 
-  function selectOption(option: AutocompleteOption) {
+  function optionIndex(sectionIndex: number, itemIndex: number) {
+    return (autocompleteSections ?? [])
+      .slice(0, sectionIndex)
+      .reduce((count, section) => count + section.items.length, 0) + itemIndex;
+  }
+
+  function selectOption(option: AutocompleteSuggestion) {
     setInputValue(option.label);
     setIsOpen(false);
     setActiveIndex(-1);
-    if (option.type === "specialite") {
-      trackSearchEvent(option.label);
-      router.push(`/medicaments/${option.specId}`);
-      return;
-    }
-    if (onSearch) {
-      onSearch(option.label);
-    } else {
-      trackSearchEvent(option.label);
-      router.push(`/rechercher?s=${option.label}`);
-    }
+    trackSearchEvent(option.label);
+    router.push(option.href);
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -178,27 +149,59 @@ export function AutocompleteSearchInput({
             boxShadow: "0 4px 8px rgba(0,0,0,0.1)",
           }}
         >
-          {options.map((option, index) => (
-            <li
-              key={`${option.type}-${option.label}-${index}`}
-              id={`${id}-option-${index}`}
-              role="option"
-              aria-selected={index === activeIndex}
-              onMouseEnter={() => setActiveIndex(index)}
-              onMouseLeave={() => setActiveIndex(-1)}
-              onMouseDown={(e) => {
-                e.preventDefault(); // prevent input blur before selection
-                selectOption(option);
-              }}
-              style={{
-                padding: "8px 16px",
-                cursor: "pointer",
-                backgroundColor: index === activeIndex
-                  ? "var(--background-alt-blue-france, #f0f0fb)"
-                  : undefined,
-              }}
-            >
-              {option.label}
+          {(autocompleteSections ?? []).map((section, sectionIndex) => (
+            <li key={section.type} role="presentation">
+              <div
+                style={{
+                  padding: "8px 16px 4px",
+                  fontSize: "0.75rem",
+                  fontWeight: 700,
+                  color: "var(--text-mention-grey, #666)",
+                  textTransform: "uppercase",
+                }}
+              >
+                {section.title}
+              </div>
+              <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+                {section.items.map((option, itemIndex) => {
+                  const index = optionIndex(sectionIndex, itemIndex);
+                  const matchReason = formatMatchReason(option.matchReasons);
+                  return (
+                    <li
+                      key={`${option.type}-${option.label}-${index}`}
+                      id={`${id}-option-${index}`}
+                      role="option"
+                      aria-selected={index === activeIndex}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      onMouseLeave={() => setActiveIndex(-1)}
+                      onMouseDown={(e) => {
+                        e.preventDefault(); // prevent input blur before selection
+                        selectOption(option);
+                      }}
+                      style={{
+                        padding: "8px 16px",
+                        cursor: "pointer",
+                        backgroundColor: index === activeIndex
+                          ? "var(--background-alt-blue-france, #f0f0fb)"
+                          : undefined,
+                      }}
+                    >
+                      <span>{option.label}</span>
+                      {matchReason && (
+                        <span
+                          style={{
+                            display: "block",
+                            color: "var(--text-mention-grey, #666)",
+                            fontSize: "0.875rem",
+                          }}
+                        >
+                          {matchReason}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
             </li>
           ))}
         </ul>

--- a/src/db/utils/autocomplete.test.ts
+++ b/src/db/utils/autocomplete.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { getAutocompleteSuggestions } from "./autocomplete";
+import { getSynonymMap } from "./searchSynonyms";
+import { getResumeSpecsATCLabels } from "./atc";
+import { formatSpecialitesResume } from "@/utils/specialites";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: any) => fn,
+}));
+
+const { dbMock, mockExecute } = vi.hoisted(() => {
+  const execute = vi.fn();
+
+  const mockDbInstance = {
+    selectFrom: vi.fn().mockReturnThis(),
+    selectAll: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    execute,
+  };
+
+  return {
+    dbMock: mockDbInstance,
+    mockExecute: execute,
+  };
+});
+
+vi.mock("@/db", () => ({
+  default: dbMock,
+}));
+
+vi.mock("./atc");
+vi.mock("@/db/pdbmMySQL", () => ({ pdbmMySQL: {} }));
+vi.mock("@/data/grist/specialites");
+vi.mock("@/utils/specialites");
+
+vi.mock("./searchSynonyms", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./searchSynonyms")>();
+  return { ...actual, getSynonymMap: vi.fn() };
+});
+
+vi.mock("server-only", () => ({}));
+
+const makeGroup = (groupName: string, composants = "") => ({
+  groupName,
+  composants,
+  indicationsIds: [],
+  atc1Code: "",
+  atc2Code: "",
+  atc5Code: "",
+  subsIds: [],
+  indicationsIdsNames: [],
+  specId: "",
+  specName: "",
+  ProcId: "",
+  isSurveillanceRenforcee: true,
+  StatutBdm: 1,
+  isAlertPregnancyPlan: true,
+  isAlertPregnancyMention: true,
+  isAlertPediatricContraindication: true,
+});
+
+describe("Autocomplete suggestions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(formatSpecialitesResume).mockImplementation((spec) =>
+      spec.map((g: any) => ({ ...g, indicationsDetails: [] })),
+    );
+    vi.mocked(getResumeSpecsATCLabels).mockImplementation(async (spec) => spec);
+    vi.mocked(getSynonymMap).mockResolvedValue([]);
+  });
+
+  it("surfaces a matched substance and linked medicines", async () => {
+    mockExecute.mockResolvedValueOnce([
+      { match_type: "substance", group_name: "DOLIPRANE", match_label: "Paracétamol", token: "paracetamol", spec_id: null, sml: 0.9, direct_sml: 0.9 },
+    ]);
+    mockExecute.mockResolvedValueOnce([
+      { ...makeGroup("DOLIPRANE", "Paracétamol"), specId: "61234567", specName: "DOLIPRANE 1000 mg" },
+    ]);
+    mockExecute.mockResolvedValueOnce([
+      { NomId: "123", NomLib: "Paracétamol" },
+    ]);
+
+    const sections = await getAutocompleteSuggestions("paracetamol");
+
+    const substanceSection = sections.find((section) => section.type === "substance");
+    const medicineSection = sections.find((section) => section.type === "specialite");
+
+    expect(substanceSection?.items[0]).toMatchObject({
+      label: "Paracétamol",
+      href: "/substances/123",
+    });
+    expect(medicineSection?.items[0]).toMatchObject({
+      href: "/medicaments/61234567",
+      matchReasons: [{ type: "substance", label: "Paracétamol" }],
+    });
+  });
+
+  it("keeps an exact medicine name ahead of a substance with the same label", async () => {
+    mockExecute.mockResolvedValueOnce([
+      { match_type: "name", group_name: "PARACETAMOL", match_label: "PARACETAMOL", token: "paracetamol", spec_id: "70000001", sml: 1, direct_sml: 1 },
+      { match_type: "substance", group_name: "DOLIPRANE", match_label: "Paracétamol", token: "paracetamol", spec_id: null, sml: 1, direct_sml: 1 },
+    ]);
+    mockExecute.mockResolvedValueOnce([
+      { ...makeGroup("PARACETAMOL", "Paracétamol"), specId: "70000001", specName: "PARACETAMOL" },
+      { ...makeGroup("DOLIPRANE", "Paracétamol"), specId: "61234567", specName: "DOLIPRANE 1000 mg" },
+    ]);
+    mockExecute.mockResolvedValueOnce([
+      { NomId: "123", NomLib: "Paracétamol" },
+    ]);
+
+    const sections = await getAutocompleteSuggestions("paracetamol");
+
+    const medicineSection = sections.find((section) => section.type === "specialite");
+
+    expect(medicineSection?.items.map((item) => item.href)).toContain("/medicaments/70000001");
+  });
+
+  it("uses cautious wording for indication-linked medicines", async () => {
+    mockExecute.mockResolvedValueOnce([
+      { match_type: "indication", group_name: "DOLIPRANE", match_label: "Migraine", token: "migraine", spec_id: null, sml: 0.95, direct_sml: 0.95 },
+    ]);
+    mockExecute.mockResolvedValueOnce([
+      { ...makeGroup("DOLIPRANE"), specId: "61234567", specName: "DOLIPRANE 1000 mg" },
+    ]);
+    mockExecute.mockResolvedValueOnce([
+      { idIndication: 42, nomIndication: "Migraine" },
+    ]);
+
+    const sections = await getAutocompleteSuggestions("migraine");
+
+    const indicationSection = sections.find((section) => section.type === "indication");
+    const medicineSection = sections.find((section) => section.type === "specialite");
+
+    expect(indicationSection?.items[0].href).toBe("/indications/42");
+    expect(medicineSection?.items[0].matchReasons).toEqual([
+      { type: "indication", label: "Migraine" },
+    ]);
+  });
+
+  it("does not expose ATC as an autocomplete category", async () => {
+    mockExecute.mockResolvedValueOnce([
+      { match_type: "atc", group_name: "DOLIPRANE", match_label: "Antalgiques", token: "antalgiques", spec_id: null, sml: 0.9, direct_sml: 0.9 },
+    ]);
+    mockExecute.mockResolvedValueOnce([
+      { ...makeGroup("DOLIPRANE"), specId: "61234567", specName: "DOLIPRANE 1000 mg" },
+    ]);
+
+    const sections = await getAutocompleteSuggestions("antalgiques");
+
+    expect(sections.map((section) => section.type)).toEqual(["specialite"]);
+  });
+});

--- a/src/db/utils/autocomplete.test.ts
+++ b/src/db/utils/autocomplete.test.ts
@@ -18,6 +18,7 @@ const { dbMock, mockExecute } = vi.hoisted(() => {
     select: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
+    as: vi.fn().mockReturnThis(),
     execute,
   };
 
@@ -74,7 +75,7 @@ describe("Autocomplete suggestions", () => {
 
   it("surfaces a matched substance and linked medicines", async () => {
     mockExecute.mockResolvedValueOnce([
-      { match_type: "substance", group_name: "DOLIPRANE", match_label: "Paracétamol", token: "paracetamol", spec_id: null, sml: 0.9, direct_sml: 0.9 },
+      { match_type: "substance", group_name: "DOLIPRANE", match_label: "Paracétamol", token: "paracetamol", spec_id: null, sml: 0.9 },
     ]);
     mockExecute.mockResolvedValueOnce([
       { ...makeGroup("DOLIPRANE", "Paracétamol"), specId: "61234567", specName: "DOLIPRANE 1000 mg" },
@@ -100,8 +101,8 @@ describe("Autocomplete suggestions", () => {
 
   it("keeps an exact medicine name ahead of a substance with the same label", async () => {
     mockExecute.mockResolvedValueOnce([
-      { match_type: "name", group_name: "PARACETAMOL", match_label: "PARACETAMOL", token: "paracetamol", spec_id: "70000001", sml: 1, direct_sml: 1 },
-      { match_type: "substance", group_name: "DOLIPRANE", match_label: "Paracétamol", token: "paracetamol", spec_id: null, sml: 1, direct_sml: 1 },
+      { match_type: "name", group_name: "PARACETAMOL", match_label: "PARACETAMOL", token: "paracetamol", spec_id: "70000001", sml: 1 },
+      { match_type: "substance", group_name: "DOLIPRANE", match_label: "Paracétamol", token: "paracetamol", spec_id: null, sml: 1 },
     ]);
     mockExecute.mockResolvedValueOnce([
       { ...makeGroup("PARACETAMOL", "Paracétamol"), specId: "70000001", specName: "PARACETAMOL" },
@@ -120,7 +121,7 @@ describe("Autocomplete suggestions", () => {
 
   it("uses cautious wording for indication-linked medicines", async () => {
     mockExecute.mockResolvedValueOnce([
-      { match_type: "indication", group_name: "DOLIPRANE", match_label: "Migraine", token: "migraine", spec_id: null, sml: 0.95, direct_sml: 0.95 },
+      { match_type: "indication", group_name: "DOLIPRANE", match_label: "Migraine", token: "migraine", spec_id: null, sml: 0.95 },
     ]);
     mockExecute.mockResolvedValueOnce([
       { ...makeGroup("DOLIPRANE"), specId: "61234567", specName: "DOLIPRANE 1000 mg" },
@@ -142,7 +143,7 @@ describe("Autocomplete suggestions", () => {
 
   it("does not expose ATC as an autocomplete category", async () => {
     mockExecute.mockResolvedValueOnce([
-      { match_type: "atc", group_name: "DOLIPRANE", match_label: "Antalgiques", token: "antalgiques", spec_id: null, sml: 0.9, direct_sml: 0.9 },
+      { match_type: "atc", group_name: "DOLIPRANE", match_label: "Antalgiques", token: "antalgiques", spec_id: null, sml: 0.9 },
     ]);
     mockExecute.mockResolvedValueOnce([
       { ...makeGroup("DOLIPRANE"), specId: "61234567", specName: "DOLIPRANE 1000 mg" },

--- a/src/db/utils/autocomplete.ts
+++ b/src/db/utils/autocomplete.ts
@@ -1,0 +1,189 @@
+"use server";
+
+import "server-cli-only";
+import db from "@/db";
+import { formatSpecName } from "@/displayUtils";
+import {
+  AutocompleteSection,
+  AutocompleteSuggestion,
+} from "@/types/SearchTypes";
+import { sql } from "kysely";
+import { unstable_cache } from "next/cache";
+import { getSearchMatches, getSearchResultsFromMatches } from "./search";
+import { normalizeString } from "@/utils/alphabeticNav";
+
+const AUTOCOMPLETE_MEDICINE_LIMIT = 5;
+const AUTOCOMPLETE_ENTITY_LIMIT = 3;
+
+export const getAutocompleteSuggestions = unstable_cache(
+  async function (query: string): Promise<AutocompleteSection[]> {
+    const matches = await getSearchMatches(query);
+    if (matches.length === 0) return [];
+
+    const searchResults = await getSearchResultsFromMatches(query, matches);
+
+    const matchesUniqueByLabel = matches.filter(
+      (match, i, arr) =>
+        arr.findIndex(
+          (other) =>
+            other.match_label.toLowerCase() === match.match_label.toLowerCase(),
+        ) === i,
+    );
+    const substanceLabels = matchesUniqueByLabel
+      .filter((match) => match.match_type === "substance")
+      .map((match) => ({
+        label: match.match_label,
+        score: match.sml + (match.direct_sml ?? 0) * 0.01,
+      }))
+      .slice(0, AUTOCOMPLETE_ENTITY_LIMIT);
+    const indicationLabels = matchesUniqueByLabel
+      .filter((match) => match.match_type === "indication")
+      .map((match) => ({
+        label: match.match_label,
+        score: match.sml + (match.direct_sml ?? 0) * 0.01,
+      }))
+      .slice(0, AUTOCOMPLETE_ENTITY_LIMIT);
+
+    const [substances, indications] = await Promise.all([
+      substanceLabels.length > 0
+        ? db
+            .selectFrom("resume_substances")
+            .select(["NomId", "NomLib"])
+            .where(({ eb, ref }) =>
+              eb(
+                sql<string>`lower(unaccent(${ref("NomLib")}))`,
+                "in",
+                substanceLabels.map((substance) =>
+                  normalizeString(substance.label),
+                ),
+              ),
+            )
+            .execute()
+        : Promise.resolve([]),
+      indicationLabels.length > 0
+        ? db
+            .selectFrom("resume_indications")
+            .select(["idIndication", "nomIndication"])
+            .where(({ eb, ref }) =>
+              eb(
+                sql<string>`lower(unaccent(${ref("nomIndication")}))`,
+                "in",
+                indicationLabels.map((indication) =>
+                  normalizeString(indication.label),
+                ),
+              ),
+            )
+            .execute()
+        : Promise.resolve([]),
+    ]);
+
+    const substanceScore = new Map(
+      substanceLabels.map(({ label, score }) => [
+        normalizeString(label),
+        score,
+      ]),
+    );
+    const substanceSuggestions = substances
+      .map((substance) => ({
+        type: "substance" as const,
+        label: substance.NomLib,
+        href: `/substances/${substance.NomId}`,
+        score: substanceScore.get(normalizeString(substance.NomLib)) ?? 0,
+      }))
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.label.localeCompare(b.label, "fr"); // alphabetical tiebreaker
+      })
+      .slice(0, AUTOCOMPLETE_ENTITY_LIMIT);
+
+    const indicationScore = new Map(
+      indicationLabels.map(({ label, score }) => [
+        normalizeString(label),
+        score,
+      ]),
+    );
+    const indicationSuggestions = indications
+      .map((indication) => ({
+        type: "indication" as const,
+        label: indication.nomIndication,
+        href: `/indications/${indication.idIndication}`,
+        score:
+          indicationScore.get(normalizeString(indication.nomIndication)) ?? 0,
+      }))
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.label.localeCompare(b.label, "fr"); // alphabetical tiebreaker
+      })
+      .slice(0, AUTOCOMPLETE_ENTITY_LIMIT);
+
+    const groupScore = new Map<string, number>();
+    for (const match of matches) {
+      const score = match.sml + (match.direct_sml ?? 0) * 0.01;
+      groupScore.set(
+        match.group_name,
+        Math.max(groupScore.get(match.group_name) ?? 0, score),
+      );
+    }
+    const medicineSuggestions = searchResults
+      .map((result) => {
+        const score = groupScore.get(result.groupName) ?? result.score;
+
+        return {
+          type: "specialite" as const,
+          label: formatSpecName(result.specName),
+          href: `/medicaments/${result.specId}`,
+          matchReasons: result.matchReasons,
+          score,
+        };
+      })
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.label.localeCompare(b.label, "fr"); // alphabetical tiebreaker
+      })
+      .slice(0, AUTOCOMPLETE_MEDICINE_LIMIT);
+
+    return autocompleteSections(
+      medicineSuggestions,
+      substanceSuggestions,
+      indicationSuggestions,
+    );
+  },
+  ["autocomplete-suggestions"],
+  { revalidate: 3600 },
+);
+
+function autocompleteSections(
+  medicines: AutocompleteSuggestion[],
+  substances: AutocompleteSuggestion[],
+  indications: AutocompleteSuggestion[],
+): AutocompleteSection[] {
+  const sections: AutocompleteSection[] = [
+    medicines.length > 0 && {
+      type: "specialite",
+      title: "Médicaments",
+      highestScore: medicines[0].score,
+      items: medicines,
+    },
+    substances.length > 0 && {
+      type: "substance",
+      title: "Substances actives",
+      highestScore: substances[0].score,
+      items: substances,
+    },
+    indications.length > 0 && {
+      type: "indication",
+      title: "Indications",
+      highestScore: indications[0].score,
+      items: indications,
+    },
+  ].filter((section): section is AutocompleteSection => Boolean(section));
+
+  return sections.sort((a, b) => {
+    if (b.highestScore !== a.highestScore)
+      return b.highestScore - a.highestScore;
+
+    // In case of a tie, sort by type priority: specialite > substance > indication
+    const order = ["specialite", "substance", "indication"];
+    return order.indexOf(a.type) - order.indexOf(b.type);
+  });
+}

--- a/src/db/utils/autocomplete.ts
+++ b/src/db/utils/autocomplete.ts
@@ -33,14 +33,14 @@ export const getAutocompleteSuggestions = unstable_cache(
       .filter((match) => match.match_type === "substance")
       .map((match) => ({
         label: match.match_label,
-        score: match.sml + (match.direct_sml ?? 0) * 0.01,
+        score: match.sml,
       }))
       .slice(0, AUTOCOMPLETE_ENTITY_LIMIT);
     const indicationLabels = matchesUniqueByLabel
       .filter((match) => match.match_type === "indication")
       .map((match) => ({
         label: match.match_label,
-        score: match.sml + (match.direct_sml ?? 0) * 0.01,
+        score: match.sml,
       }))
       .slice(0, AUTOCOMPLETE_ENTITY_LIMIT);
 
@@ -118,10 +118,9 @@ export const getAutocompleteSuggestions = unstable_cache(
 
     const groupScore = new Map<string, number>();
     for (const match of matches) {
-      const score = match.sml + (match.direct_sml ?? 0) * 0.01;
       groupScore.set(
         match.group_name,
-        Math.max(groupScore.get(match.group_name) ?? 0, score),
+        Math.max(groupScore.get(match.group_name) ?? 0, match.sml),
       );
     }
     const medicineSuggestions = searchResults

--- a/src/db/utils/index.ts
+++ b/src/db/utils/index.ts
@@ -6,6 +6,7 @@ export {
   getSpecialite,
 } from "./specialities";
 export { getPresentations, presentationIsComm } from "./presentation";
+export { getAutocompleteSuggestions } from "./autocomplete";
 export { getSearchResults } from "./search";
 export { getSynonymSuggestion } from "./searchSynonyms";
 export { groupGeneNameToDCI } from "@/displayUtils";
@@ -30,4 +31,3 @@ export const getLeafletImage = async ({ src }: { src: string }) => {
     throw e;
   }
 };
-

--- a/src/db/utils/search.test.ts
+++ b/src/db/utils/search.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { getSearchResults } from "./search";
-import { buildRequiredTermGroups } from "./searchTerms";
 import { computeSortScore } from "./searchScoring";
 import { getSynonymMap } from "./searchSynonyms";
 import { getResumeSpecsATCLabels } from "./atc";
@@ -70,23 +69,6 @@ const makeGroup = (groupName: string, composants = "") => ({
   isAlertPregnancyPlan: true,
   isAlertPregnancyMention: true,
   isAlertPediatricContraindication: true,
-});
-
-describe("buildRequiredTermGroups", () => {
-  it("requires every meaningful word from a multi-word query", () => {
-    expect(buildRequiredTermGroups(["acide folique"])).toEqual([["acide", "folique"]]);
-  });
-
-  it("keeps synonym canonical terms as an alternative required term group", () => {
-    expect(buildRequiredTermGroups(["mal de tete", "cephalees"])).toEqual([
-      ["mal", "tete"],
-      ["cephalees"],
-    ]);
-  });
-
-  it("ignores connector-only queries", () => {
-    expect(buildRequiredTermGroups(["de la"])).toEqual([]);
-  });
 });
 
 describe("Search Engine (getSearchResults)", () => {

--- a/src/db/utils/search.test.ts
+++ b/src/db/utils/search.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { getSearchResults } from "./search";
+import { buildRequiredTermGroups } from "./searchTerms";
 import { computeSortScore } from "./searchScoring";
 import { getSynonymMap } from "./searchSynonyms";
 import { getResumeSpecsATCLabels } from "./atc";
@@ -22,6 +23,7 @@ const { dbMock, mockExecute } = vi.hoisted(() => {
     select: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
+    as: vi.fn().mockReturnThis(),
     execute: execute,
   };
 
@@ -68,6 +70,23 @@ const makeGroup = (groupName: string, composants = "") => ({
   isAlertPregnancyPlan: true,
   isAlertPregnancyMention: true,
   isAlertPediatricContraindication: true,
+});
+
+describe("buildRequiredTermGroups", () => {
+  it("requires every meaningful word from a multi-word query", () => {
+    expect(buildRequiredTermGroups(["acide folique"])).toEqual([["acide", "folique"]]);
+  });
+
+  it("keeps synonym canonical terms as an alternative required term group", () => {
+    expect(buildRequiredTermGroups(["mal de tete", "cephalees"])).toEqual([
+      ["mal", "tete"],
+      ["cephalees"],
+    ]);
+  });
+
+  it("ignores connector-only queries", () => {
+    expect(buildRequiredTermGroups(["de la"])).toEqual([]);
+  });
 });
 
 describe("Search Engine (getSearchResults)", () => {

--- a/src/db/utils/search.ts
+++ b/src/db/utils/search.ts
@@ -10,19 +10,29 @@ import { formatSpecialitesResume } from "@/utils/specialites";
 import { computeSortScore } from "./searchScoring";
 import { expandQuery, getSynonymMap } from "./searchSynonyms";
 import { MatchReason, SearchResultItem } from "@/types/SearchTypes";
+import { normalizeString } from "@/utils/alphabeticNav";
 
+export type SearchIndexMatch = SearchResult & {
+  sml: number;
+  direct_sml?: number;
+};
 
-export const getSearchResults = unstable_cache(async function (
+type GroupMatch = {
+  score: number;
+  directScore: number;
+  reasons: MatchReason[];
+};
+
+export async function getSearchMatches(
   query: string,
-): Promise<SearchResultItem[]> {
-
+): Promise<SearchIndexMatch[]> {
   // empty query returns no results
   if (!query || query.trim().length === 0) {
     return [];
   }
 
   // Normalize to lowercase+unaccented to match how tokens are stored in the index
-  const normalizedQuery = query.toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+  const normalizedQuery = normalizeString(query);
 
   // Expand with curated synonyms: a lay term ("mal de tête") adds its canonical
   // medical term ("céphalées") as an extra search term. Additive — no synonym match
@@ -34,11 +44,13 @@ export const getSearchResults = unstable_cache(async function (
   const smlExpr = sql<number>`greatest(${sql.join(
     terms.map((term) => sql`word_similarity(${term}, token)`),
   )})`;
+  const directSmlExpr = sql<number>`word_similarity(${normalizedQuery}, token)`;
 
-  const matches = (await db
+  return await db
     .selectFrom("search_index")
     .selectAll()
     .select(smlExpr.as("sml"))
+    .select(directSmlExpr.as("direct_sml"))
     .where((eb) => {
       // Same tiered matching as before, applied per term and OR-ed together.
       const termPredicate = (term: string) => {
@@ -63,32 +75,61 @@ export const getSearchResults = unstable_cache(async function (
     })
     .orderBy("sml", "desc")
     .orderBy(({ fn }) => fn("length", ["token"]))
-    .execute()) as (SearchResult & { sml: number })[];
+    .execute();
+}
 
-  if (matches.length === 0) return [];
+function groupMatches(matches: SearchIndexMatch[]) {
+  if (matches.length === 0) return undefined;
 
   // Group by group_name to deduplicate, collect best score + match reasons
-  const groupMap = new Map<string, { score: number; reasons: MatchReason[] }>();
+  const groupMap = new Map<string, GroupMatch>();
   // Per-spécialité name similarity: best sml of a "name" token attributed to a specId.
   // Lets us rank variants within a group (e.g. "Doliprane 1000" above "Doliprane 500").
   const specNameSml = new Map<string, number>();
   for (const match of matches) {
     const matchGroup = groupMap.get(match.group_name);
-    const reason: MatchReason = { type: match.match_type, label: match.match_label };
+    const reason: MatchReason = {
+      type: match.match_type,
+      label: match.match_label,
+    };
+    const directScore = match.direct_sml ?? match.sml;
     if (matchGroup) {
       matchGroup.score = Math.max(matchGroup.score, match.sml);
+      matchGroup.directScore = Math.max(matchGroup.directScore, directScore);
       // Deduplicate: the seed can produce identical rows per group, e.g. when
       // multiple subsIds resolve to the same substance name, or duplicate indicationsIds
-      if (!matchGroup.reasons.some((r) => r.type === reason.type && r.label === reason.label)) {
+      if (
+        !matchGroup.reasons.some(
+          (r) => r.type === reason.type && r.label === reason.label,
+        )
+      ) {
         matchGroup.reasons.push(reason);
       }
     } else {
-      groupMap.set(match.group_name, { score: match.sml, reasons: [reason] });
+      groupMap.set(match.group_name, {
+        score: match.sml,
+        directScore,
+        reasons: [reason],
+      });
     }
     if (match.match_type === "name" && match.spec_id) {
-      specNameSml.set(match.spec_id, Math.max(specNameSml.get(match.spec_id) ?? 0, match.sml));
+      specNameSml.set(
+        match.spec_id,
+        Math.max(specNameSml.get(match.spec_id) ?? 0, match.sml),
+      );
     }
   }
+  return { groupMap, specNameSml };
+}
+
+export async function getSearchResultsFromMatches(
+  query: string,
+  matches: SearchIndexMatch[],
+): Promise<SearchResultItem[]> {
+  const grouped = groupMatches(matches);
+  if (!grouped) return [];
+
+  const { groupMap, specNameSml } = grouped;
 
   // Fetch up to 500 candidate groups so computeSortScore can rank them properly
   // before trimming to the final 100. A tighter pre-filter here caused well-known
@@ -114,11 +155,23 @@ export const getSearchResults = unstable_cache(async function (
       const matchReasons = groupMap.get(spec.groupName)?.reasons ?? [];
       // Prefer this spécialité's own name similarity so variants rank against the query
       // individually; fall back to the group's best score for substance/atc/indication matches.
-      const baseSml = specNameSml.get(spec.specId) ?? groupMap.get(spec.groupName)?.score ?? 0;
+      const baseSml =
+        specNameSml.get(spec.specId) ??
+        groupMap.get(spec.groupName)?.score ??
+        0;
+      const directScore = groupMap.get(spec.groupName)?.directScore ?? baseSml;
       return {
         ...spec,
         matchReasons,
-        score: computeSortScore(query, spec.specName, spec.composants, matchReasons, baseSml),
+        score:
+          computeSortScore(
+            query,
+            spec.specName,
+            spec.composants,
+            matchReasons,
+            baseSml,
+          ) +
+          directScore * 0.01,
       };
     })
     .sort((a, b) => {
@@ -126,7 +179,13 @@ export const getSearchResults = unstable_cache(async function (
       return a.specName.localeCompare(b.specName, "fr"); // alphabetical tiebreaker
     })
     .slice(0, 200);
-},
+}
+
+export const getSearchResults = unstable_cache(
+  async function (query: string): Promise<SearchResultItem[]> {
+    const matches = await getSearchMatches(query);
+    return getSearchResultsFromMatches(query, matches);
+  },
   ["search-results"],
-  { revalidate: 3600 } // 1 hour caching max
+  { revalidate: 3600 }, // 1 hour caching max
 );

--- a/src/db/utils/search.ts
+++ b/src/db/utils/search.ts
@@ -169,8 +169,7 @@ export async function getSearchResultsFromMatches(
     .sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;
       return a.specName.localeCompare(b.specName, "fr"); // alphabetical tiebreaker
-    })
-    .slice(0, 200);
+    });
 }
 
 export const getSearchResults = unstable_cache(

--- a/src/db/utils/search.ts
+++ b/src/db/utils/search.ts
@@ -3,7 +3,6 @@
 import "server-cli-only";
 import db from "@/db";
 import { SearchResult } from "@/db/types";
-import { sql } from "kysely";
 import { unstable_cache } from "next/cache";
 import { getResumeSpecsATCLabels } from "@/db/utils/atc";
 import { formatSpecialitesResume } from "@/utils/specialites";
@@ -11,15 +10,19 @@ import { computeSortScore } from "./searchScoring";
 import { expandQuery, getSynonymMap } from "./searchSynonyms";
 import { MatchReason, SearchResultItem } from "@/types/SearchTypes";
 import { normalizeString } from "@/utils/alphabeticNav";
+import {
+  buildRequiredTermGroups,
+  rowMatchesRequiredTermsPredicate,
+} from "./searchTerms";
+
+const MIN_SEARCH_SIMILARITY = 0.55;
 
 export type SearchIndexMatch = SearchResult & {
   sml: number;
-  direct_sml?: number;
 };
 
 type GroupMatch = {
   score: number;
-  directScore: number;
   reasons: MatchReason[];
 };
 
@@ -33,46 +36,41 @@ export async function getSearchMatches(
 
   // Normalize to lowercase+unaccented to match how tokens are stored in the index
   const normalizedQuery = normalizeString(query);
+  if (normalizedQuery.length === 0) {
+    return [];
+  }
 
   // Expand with curated synonyms: a lay term ("mal de tête") adds its canonical
   // medical term ("céphalées") as an extra search term. Additive — no synonym match
   // leaves terms = [normalizedQuery], i.e. unchanged behaviour.
-  const terms = expandQuery(normalizedQuery, await getSynonymMap());
+  const queryAndSynonyms = expandQuery(normalizedQuery, await getSynonymMap());
+  // Gives us [["mal", "tête"], ["céphalées"]]
+  // Eg: when searching for "acide folique" we dont want to match on "acide" alone
+  const requiredTermGroups = buildRequiredTermGroups(queryAndSynonyms);
+  if (requiredTermGroups.length === 0) {
+    return [];
+  }
 
-  // Each match's similarity is the best (GREATEST) word_similarity across all terms,
-  // so a synonym-driven hit scores against its canonical term, not the lay query.
-  const smlExpr = sql<number>`greatest(${sql.join(
-    terms.map((term) => sql`word_similarity(${term}, token)`),
-  )})`;
-  const directSmlExpr = sql<number>`word_similarity(${normalizedQuery}, token)`;
-
-  return await db
+  const matchesQuery = db
     .selectFrom("search_index")
     .selectAll()
-    .select(smlExpr.as("sml"))
-    .select(directSmlExpr.as("direct_sml"))
-    .where((eb) => {
-      // Same tiered matching as before, applied per term and OR-ed together.
-      const termPredicate = (term: string) => {
-        if (term.length <= 3) {
-          // for very short queries, only match from the beginning to limit the number of results
-          // also, we only match specialities
-          return eb.and([
-            eb("token", "like", `${term}%`),
-            eb("match_type", "=", "name"),
-          ]);
-        }
-        if (term.length <= 5) {
-          // if the query is short, we only do ilike search to avoid too many results
-          return eb("token", "like", `%${term}%`);
-        }
-        return eb.or([
-          sql<boolean>`token %> ${term}`, // fuzzy-search using pg_trgm
-          eb("token", "like", `%${term}%`), // exact match
-        ]);
-      };
-      return eb.or(terms.map(termPredicate));
-    })
+    .select((eb) =>
+      eb
+        .fn<number>(
+          "greatest",
+          queryAndSynonyms.map((term) =>
+            eb.fn<number>("word_similarity", [eb.val(term), "token"]),
+          ),
+        )
+        .as("sml"),
+    )
+    .where((eb) => rowMatchesRequiredTermsPredicate(eb, requiredTermGroups))
+    .as("matches");
+
+  return await db
+    .selectFrom(matchesQuery)
+    .selectAll()
+    .where("sml", ">=", MIN_SEARCH_SIMILARITY)
     .orderBy("sml", "desc")
     .orderBy(({ fn }) => fn("length", ["token"]))
     .execute();
@@ -92,10 +90,8 @@ function groupMatches(matches: SearchIndexMatch[]) {
       type: match.match_type,
       label: match.match_label,
     };
-    const directScore = match.direct_sml ?? match.sml;
     if (matchGroup) {
       matchGroup.score = Math.max(matchGroup.score, match.sml);
-      matchGroup.directScore = Math.max(matchGroup.directScore, directScore);
       // Deduplicate: the seed can produce identical rows per group, e.g. when
       // multiple subsIds resolve to the same substance name, or duplicate indicationsIds
       if (
@@ -108,7 +104,6 @@ function groupMatches(matches: SearchIndexMatch[]) {
     } else {
       groupMap.set(match.group_name, {
         score: match.sml,
-        directScore,
         reasons: [reason],
       });
     }
@@ -159,19 +154,16 @@ export async function getSearchResultsFromMatches(
         specNameSml.get(spec.specId) ??
         groupMap.get(spec.groupName)?.score ??
         0;
-      const directScore = groupMap.get(spec.groupName)?.directScore ?? baseSml;
       return {
         ...spec,
         matchReasons,
-        score:
-          computeSortScore(
-            query,
-            spec.specName,
-            spec.composants,
-            matchReasons,
-            baseSml,
-          ) +
-          directScore * 0.01,
+        score: computeSortScore(
+          query,
+          spec.specName,
+          spec.composants,
+          matchReasons,
+          baseSml,
+        ),
       };
     })
     .sort((a, b) => {
@@ -184,6 +176,7 @@ export async function getSearchResultsFromMatches(
 export const getSearchResults = unstable_cache(
   async function (query: string): Promise<SearchResultItem[]> {
     const matches = await getSearchMatches(query);
+    console.log(matches);
     return getSearchResultsFromMatches(query, matches);
   },
   ["search-results"],

--- a/src/db/utils/search.ts
+++ b/src/db/utils/search.ts
@@ -11,8 +11,8 @@ import { expandQuery, getSynonymMap } from "./searchSynonyms";
 import { MatchReason, SearchResultItem } from "@/types/SearchTypes";
 import { normalizeString } from "@/utils/alphabeticNav";
 import {
-  buildRequiredTermGroups,
   rowMatchesRequiredTermsPredicate,
+  termsSimilarityExpression,
 } from "./searchTerms";
 
 const MIN_SEARCH_SIMILARITY = 0.55;
@@ -44,27 +44,15 @@ export async function getSearchMatches(
   // medical term ("céphalées") as an extra search term. Additive — no synonym match
   // leaves terms = [normalizedQuery], i.e. unchanged behaviour.
   const queryAndSynonyms = expandQuery(normalizedQuery, await getSynonymMap());
-  // Gives us [["mal", "tête"], ["céphalées"]]
-  // Eg: when searching for "acide folique" we dont want to match on "acide" alone
-  const requiredTermGroups = buildRequiredTermGroups(queryAndSynonyms);
-  if (requiredTermGroups.length === 0) {
-    return [];
-  }
 
   const matchesQuery = db
     .selectFrom("search_index")
     .selectAll()
-    .select((eb) =>
-      eb
-        .fn<number>(
-          "greatest",
-          queryAndSynonyms.map((term) =>
-            eb.fn<number>("word_similarity", [eb.val(term), "token"]),
-          ),
-        )
-        .as("sml"),
-    )
-    .where((eb) => rowMatchesRequiredTermsPredicate(eb, requiredTermGroups))
+    .select((eb) => {
+      const smlExpr = termsSimilarityExpression(eb, queryAndSynonyms);
+      return smlExpr.as("sml");
+    })
+    .where((eb) => rowMatchesRequiredTermsPredicate(eb, queryAndSynonyms))
     .as("matches");
 
   return await db
@@ -175,7 +163,6 @@ export async function getSearchResultsFromMatches(
 export const getSearchResults = unstable_cache(
   async function (query: string): Promise<SearchResultItem[]> {
     const matches = await getSearchMatches(query);
-    console.log(matches);
     return getSearchResultsFromMatches(query, matches);
   },
   ["search-results"],

--- a/src/db/utils/searchTerms.ts
+++ b/src/db/utils/searchTerms.ts
@@ -1,4 +1,10 @@
-import { Expression, ExpressionBuilder, SqlBool, sql } from "kysely";
+import {
+  AliasableExpression,
+  Expression,
+  ExpressionBuilder,
+  SqlBool,
+  sql,
+} from "kysely";
 import type { Database } from "@/db/types";
 
 const CONNECTOR_WORDS = new Set([
@@ -17,7 +23,7 @@ const CONNECTOR_WORDS = new Set([
   "les",
 ]);
 
-export function buildRequiredTermGroups(terms: string[]): string[][] {
+function buildRequiredTermGroups(terms: string[]): string[][] {
   const requiredTermGroupsByKey = new Map<string, string[]>();
 
   for (const term of terms) {
@@ -32,6 +38,19 @@ export function buildRequiredTermGroups(terms: string[]): string[][] {
   }
 
   return [...requiredTermGroupsByKey.values()];
+}
+
+export function termsSimilarityExpression(
+  eb: ExpressionBuilder<Database, "search_index">,
+  terms: string[],
+): AliasableExpression<number> {
+  const termSimilarities = terms.map((term) =>
+    eb.fn<number>("word_similarity", [eb.val(term), "token"]),
+  );
+
+  return termSimilarities.length === 1
+    ? termSimilarities[0]
+    : eb.fn<number>("greatest", termSimilarities);
 }
 
 function wordMatchPredicate(
@@ -58,9 +77,13 @@ function wordMatchPredicate(
 
 export function rowMatchesRequiredTermsPredicate(
   eb: ExpressionBuilder<Database, "search_index">,
-  requiredTermGroups: string[][],
+  terms: string[],
 ): Expression<SqlBool> {
-  if (requiredTermGroups.length === 0) return eb.val(true);
+  // Gives us [["mal", "tête"], ["céphalées"]]
+  // Eg: when searching for "acide folique" we dont want to match on "acide" alone
+  const requiredTermGroups = buildRequiredTermGroups(terms);
+
+  if (requiredTermGroups.length === 0) return eb.val(false);
 
   const requiredTermGroupPredicates = requiredTermGroups.map((requiredTerms) =>
     eb.and(requiredTerms.map((word) => wordMatchPredicate(eb, word))),

--- a/src/db/utils/searchTerms.ts
+++ b/src/db/utils/searchTerms.ts
@@ -1,0 +1,70 @@
+import { Expression, ExpressionBuilder, SqlBool, sql } from "kysely";
+import type { Database } from "@/db/types";
+
+const CONNECTOR_WORDS = new Set([
+  "a",
+  "au",
+  "aux",
+  "d",
+  "de",
+  "des",
+  "du",
+  "en",
+  "et",
+  "l",
+  "la",
+  "le",
+  "les",
+]);
+
+export function buildRequiredTermGroups(terms: string[]): string[][] {
+  const requiredTermGroupsByKey = new Map<string, string[]>();
+
+  for (const term of terms) {
+    const words = term.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+    const meaningfulWords = words.filter((word) => !CONNECTOR_WORDS.has(word));
+    const requiredTerms = [...new Set(meaningfulWords)];
+    const key = requiredTerms.join(" ");
+
+    if (requiredTerms.length > 0 && !requiredTermGroupsByKey.has(key)) {
+      requiredTermGroupsByKey.set(key, requiredTerms);
+    }
+  }
+
+  return [...requiredTermGroupsByKey.values()];
+}
+
+function wordMatchPredicate(
+  eb: ExpressionBuilder<Database, "search_index">,
+  word: string,
+): Expression<SqlBool> {
+  // for very short queries, only match from the beginning to limit the number of results
+  // also, we only match specialities
+  if (word.length <= 3) {
+    return eb.and([
+      eb("token", "like", `${word}%`),
+      eb("match_type", "=", "name"),
+    ]);
+  }
+  // if the query is short, we only do ilike search to avoid too many results
+  if (word.length <= 5) {
+    return eb("token", "like", `%${word}%`);
+  }
+  return eb.or([
+    sql<boolean>`${eb.ref("token")} %> ${word}`,
+    eb("token", "like", `%${word}%`),
+  ]);
+}
+
+export function rowMatchesRequiredTermsPredicate(
+  eb: ExpressionBuilder<Database, "search_index">,
+  requiredTermGroups: string[][],
+): Expression<SqlBool> {
+  if (requiredTermGroups.length === 0) return eb.val(true);
+
+  const requiredTermGroupPredicates = requiredTermGroups.map((requiredTerms) =>
+    eb.and(requiredTerms.map((word) => wordMatchPredicate(eb, word))),
+  );
+
+  return eb.or(requiredTermGroupPredicates);
+}

--- a/src/types/SearchTypes.tsx
+++ b/src/types/SearchTypes.tsx
@@ -26,3 +26,20 @@ export type SearchResultItem = ResumeSpecialite & {
   matchReasons: MatchReason[];
   score: number;
 };
+
+export type AutocompleteSuggestionType = "specialite" | "substance" | "indication";
+
+export type AutocompleteSuggestion = {
+  type: AutocompleteSuggestionType;
+  label: string;
+  href: string;
+  score: number;
+  matchReasons?: MatchReason[];
+};
+
+export type AutocompleteSection = {
+  type: AutocompleteSuggestionType;
+  title: string;
+  highestScore: number;
+  items: AutocompleteSuggestion[];
+};

--- a/src/utils/alphabeticNav.ts
+++ b/src/utils/alphabeticNav.ts
@@ -1,4 +1,7 @@
+export function normalizeString(value: string): string {
+  return value.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
 export function getNormalizeLetter(letter: string): string {
-  const newLetter = letter.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-  return newLetter.toUpperCase();
+  return normalizeString(letter).toUpperCase();
 }


### PR DESCRIPTION
- Adds a dedicated autocomplete API route backed by the existing search index.
- Introduces ranked autocomplete suggestions grouped by medicines, active substances, and indications.
- Refactors search utilities so autocomplete and full search share match/ranking logic.
- Moves autocomplete UI under `components/search/autocomplete` and updates imports.