### PR TITLE
feat: render parsed notice/RCP for centralised medicines when content exists

### DIFF
--- a/src/app/(container)/medicaments/[CIS]/page.tsx
+++ b/src/app/(container)/medicaments/[CIS]/page.tsx
@@ -12,7 +12,7 @@ import { getWarmupCISCodes } from "@/db/utils/warmup";
 import { pdbmMySQL } from "@/db/pdbmMySQL";
 import ContentContainer from "@/components/generic/ContentContainer";
 import RatingToaster from "@/components/rating/RatingToaster";
-import { getSpecialiteGroupName, isCentralisee } from "@/utils/specialites";
+import { getSpecialiteGroupName } from "@/utils/specialites";
 import { getAtcCode } from "@/utils/atc";
 import { getSpecialiteMetadata, getSpecialiteName } from "@/db/utils/specialities";
 import MedicamentContent from "@/components/medicaments/MedicamentContent";
@@ -57,7 +57,7 @@ async function fetchMedicamentData(
     allPregnancyPlanAlerts,
     specialitePathologies,
   ] = await Promise.all([
-    !isCentralisee(specialite) ? getNotice(CIS) : Promise.resolve(undefined),
+    getNotice(CIS),
     getFicheInfos(CIS),
     getHighlightedGlossaryDefinitions(),
     getPregnancyMentionAlert(CIS),

--- a/src/components/medicaments/advanced/RcpBlock.tsx
+++ b/src/components/medicaments/advanced/RcpBlock.tsx
@@ -31,10 +31,8 @@ function RcpBlock({
       spec: DetailedSpecialite,
     ) => {
       try {
-        if(!isCentralisee(spec)) {
-          const newNotice = await getRCP(spec.SpecId);
-          setCurrentRcp(newNotice);
-        }
+        const newNotice = await getRCP(spec.SpecId);
+        setCurrentRcp(newNotice);
         setLoaded(true);
       } catch (e) {
         Sentry.captureException(e);
@@ -52,11 +50,7 @@ function RcpBlock({
   return (
     <>
       <h2>Résumé des caractéristiques du produit</h2>
-      {(currentSpec && isCentralisee(currentSpec)) ? (
-          <CentraliseBlock
-            pdfURL={currentSpec.urlCentralise ? currentSpec.urlCentralise : undefined}
-          />
-        ) : currentRcp ? (
+      {currentRcp ? (
           <>
             {currentRcp.dateNotif && (
               <Badge severity={"info"} className={fr.cx("fr-mb-4w")}>{currentRcp.dateNotif}</Badge>
@@ -65,6 +59,10 @@ function RcpBlock({
               <RcpNoticeContainer>{getContent(currentRcp.children)}</RcpNoticeContainer>
             )}
           </>
+        ) : (currentSpec && isCentralisee(currentSpec)) ? (
+          <CentraliseBlock
+            pdfURL={currentSpec.urlCentralise ? currentSpec.urlCentralise : undefined}
+          />
         ) : (
           loaded && (<span>Le résumé des caractéristiques du produit n&rsquo;est pas disponible pour ce médicament.</span>)
         )}

--- a/src/components/medicaments/notice/NoticeBlock.tsx
+++ b/src/components/medicaments/notice/NoticeBlock.tsx
@@ -44,13 +44,13 @@ function NoticeBlock({
       className={[props.className, fr.cx("fr-mt-3w")].join(" ")}
     >
       <ContentContainer className={noticeContainerClassName} id="noticeContainer">
-        {(specialite && isCentralisee(specialite)) ? (
+        {(notice && notice.children) ? (
+          <RcpNoticeContainer>{getContent(notice.children, definitions)}</RcpNoticeContainer>
+        ) : (specialite && isCentralisee(specialite)) ? (
           <CentraliseBlock
             pdfURL={specialite.urlCentralise ? specialite.urlCentralise : undefined}
           />
-        ) : (notice && notice.children) && (
-          <RcpNoticeContainer>{getContent(notice.children, definitions)}</RcpNoticeContainer>
-        )}
+        ) : null}
       </ContentContainer>
     </NoticeBlockContainer>
   );


### PR DESCRIPTION
Centrally-authorised medicines now have their EMA product-information PDFs parsed into the notices/rcp tables with the same block-tree shape as ANSM-sourced content. Previously the frontend short-circuited every centralised specialité straight to CentraliseBlock (a link to the EMA PDF) and never queried or rendered the parsed tree.

Switch the decision from "is this specialité centralised?" to "does this CIS have notice/rcp content in the DB?", per-CIS:
  - page.tsx: always call getNotice(CIS) instead of skipping it for centralised specialités; getNotice returns undefined per-CIS when no row exists.
  - NoticeBlock: render the parsed notice tree when notice.children exists, falling back to CentraliseBlock only when it doesn't.
  - RcpBlock: always fetch getRCP(spec.SpecId), and render the parsed RCP tree when present, falling back to CentraliseBlock otherwise.